### PR TITLE
Release 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ EULA is available at [EULA website] [LICENSE]
 ##### Add YandexMobileAds SDK:
 
 ```sh
-implementation 'com.yandex.android:mobileads:7.18.4'
+implementation 'com.yandex.android:mobileads:8.0.0-beta.1'
 ```
 
 ##### Or you can use our library with all available mediations:
@@ -31,7 +31,7 @@ implementation 'com.yandex.android:mobileads:7.18.4'
 
 dependencies {
   ...
-  implementation 'com.yandex.android:mobileads-mediation:7.18.4.0'
+  implementation 'com.yandex.android:mobileads-mediation:8.0.0.0-beta.1'
 }
 ```
 
@@ -65,7 +65,7 @@ allprojects {
 ```
 
 
-##### Note, for correct work of SDK you need Android Gradle Plugin version 8.3.2
+##### Note, for correct work of SDK you need Android Gradle Plugin version 8.8.2
 
 [DOCUMENTATION]: https://tech.yandex.com/mobile-ads/
 [LICENSE]: https://legal.yandex.com/partner_ch/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ EULA is available at [EULA website] [LICENSE]
 ##### Add YandexMobileAds SDK:
 
 ```sh
-implementation 'com.yandex.android:mobileads:8.0.0-beta.2'
+implementation 'com.yandex.android:mobileads:8.0.0'
 ```
 
 ##### Or you can use our library with all available mediations:
@@ -31,7 +31,7 @@ implementation 'com.yandex.android:mobileads:8.0.0-beta.2'
 
 dependencies {
   ...
-  implementation 'com.yandex.android:mobileads-mediation:8.0.0.0-beta.2'
+  implementation 'com.yandex.android:mobileads-mediation:8.0.0.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ EULA is available at [EULA website] [LICENSE]
 ##### Add YandexMobileAds SDK:
 
 ```sh
-implementation 'com.yandex.android:mobileads:8.0.0-beta.1'
+implementation 'com.yandex.android:mobileads:8.0.0-beta.2'
 ```
 
 ##### Or you can use our library with all available mediations:
@@ -31,7 +31,7 @@ implementation 'com.yandex.android:mobileads:8.0.0-beta.1'
 
 dependencies {
   ...
-  implementation 'com.yandex.android:mobileads-mediation:8.0.0.0-beta.1'
+  implementation 'com.yandex.android:mobileads-mediation:8.0.0.0-beta.2'
 }
 ```
 

--- a/ThirdPartyMediationAdapterTemplate/README.md
+++ b/ThirdPartyMediationAdapterTemplate/README.md
@@ -35,14 +35,14 @@ See [also](https://yandex.ru/support2/mobile-ads/en/dev/android/quick-start#app)
 Copy [YandexAdapters](./app/src/main/java/com/example/mediation/YandexAdapters.kt) file content and change stub API to your actual API.
 This way you will get a separate adapter class for each of the ad formats. If your API requires a single class for all formats, you can merge classes.
 
-* Mediation parameters must be set for each request as shown in the [template](./app/src/main/java/com/example/mediation/YandexAdapters.kt#L631):
-    * `"adapter_version"` represents Yandex adapter version. Construct this version by adding one more number to the Yandex SDK version. For example, `6.2.1.0` if the Yandex SDK version is `6.2.1`. If you need to update an adapter without changing the Yandex SDK version, increment the fourth number like `6.2.1.1`.
-    * `"adapter_network_name"` represents your ad network name in lowercase.
-    * `"adapter_network_sdk_version"` represents your ad network SDK version.
+* When using `YandexAds.setAdapterIdentity(AdapterIdentity)`, adapter identity parameters are automatically added to all requests:
+    * `adapterVersion` represents Yandex adapter version. Construct this version by adding one more number to the Yandex SDK version. For example, `6.2.1.0` if the Yandex SDK version is `6.2.1`. If you need to update an adapter without changing the Yandex SDK version, increment the fourth number like `6.2.1.1`.
+    * `adapterNetworkName` represents your ad network name in lowercase.
+    * `adapterNetworkVersion` represents your ad network SDK version.
 
-* `Interstitial`, `Rewarded`, `AppOpen` and `Native` formats provide loader classes. A loader object can be [created](./app/src/main/java/com/example/mediation/YandexAdapters.kt#L60) once and can be reused. This speeds up loading and can be helpful to implement preloading logic, if your network supports it.
+* `Interstitial`, `Rewarded`, `AppOpen` and `Native` formats provide loader classes. A loader object can be created once and can be reused. This speeds up loading and can be helpful to implement preloading logic, if your network supports it.
 
-* `Native` format includes both the required and optional [assets](https://yandex.ru/support2/mobile-ads/en/dev/android/components). The way to provide custom assets for binding strongly depends on the API of your ads SDK. The [template](./app/src/main/java/com/example/mediation/YandexAdapters.kt#L690) shows how these assets are passed to adapter during the ad request by providing a map of `string identifier` to `asset view identifier` on the publisher side.
+* `Native` format includes both the required and optional [assets](https://yandex.ru/support2/mobile-ads/en/dev/android/components). The way to provide custom assets for binding strongly depends on the API of your ads SDK. The template shows how these assets are passed to adapter during the ad request by providing a map of `string identifier` to `asset view identifier` on the publisher side.
 
 ### 4. Test integration
 
@@ -70,7 +70,22 @@ Successfully initializing the Yandex Mobile Ads SDK is an important condition fo
 </manifest>
 ```
 
-Manual initialization of the SDK can be used like this (this method is safety and can be reinvoked if SDK already initialized):
+For mediation adapters, use `YandexAds.setAdapterIdentity(AdapterIdentity)` method which stores the adapter identity globally and automatically adds adapter parameters to all requests:
+
+```java
+void loadAd() {
+  AdapterIdentity adapterIdentity = new AdapterIdentity("AdNetwork", "1.0.0", "1.2.3");
+  YandexAds.setAdapterIdentity(adapterIdentity); // Call before initialize()
+  YandexAds.initialize(this, () -> { /* ... */ });
+
+  // No need to pass additional parameters
+  AdRequest adRequest = new AdRequest.Builder("R-M-XXXXX-YY").build();
+
+  bannerView.loadAd(adRequest);
+}
+```
+
+For reqular integration, use the standard initialization:
 ```kotlin
 MobileAds.initialize(context) {
     onInitializationComplete.invoke()
@@ -91,7 +106,7 @@ See also: [GDPR](https://yandex.ru/support2/mobile-ads/en/dev/android/gdpr) and 
 
 ### S2S bidding integration
 
-As shown in the [template](./app/src/main/java/com/example/mediation/YandexAdapters.kt#L664), the bidder token can be obtained as follows:
+The bidder token can be obtained using the `BidderTokenLoader` class:
 
 ```kotlin
 val loadListener = object : BidderTokenLoadListener {
@@ -99,21 +114,23 @@ val loadListener = object : BidderTokenLoadListener {
     override fun onBidderTokenFailedToLoad(msg: String) = callback.onTokenFailedToLoad()
 }
 
-BidderTokenLoader.loadBidderToken(context, tokenRequest, loadListener)
+// Create an instance of BidderTokenLoader
+val bidderTokenLoader = BidderTokenLoader(context)
+bidderTokenLoader.loadBidderToken(tokenRequest, loadListener)
 ```
 
-You need to load a bidder token for each new ad request. Token request can be created as follows (also shown in [template](./app/src/main/java/com/example/mediation/YandexAdapters.kt#L611)):
+You need to load a bidder token for each new ad request. Token request can be created as follows:
 
 ```kotlin
 fun createBidderTokenRequestConfiguration(): BidderTokenRequestConfiguration {
-        val requestBuilder = BidderTokenRequestConfiguration.Builder(adType)
-
-        if (adType == AdType.BANNER) {
-            requestBuilder.setBannerAdSize(bannerAdSize)
-        }
-
-        return requestBuilder
-            .setParameters(mediationParameters)
-            .build()
+    return when (adType) {
+        AdType.BANNER -> BidderTokenRequestConfiguration.banner(bannerAdSize)
+        AdType.INTERSTITIAL -> BidderTokenRequestConfiguration.interstitial()
+        AdType.REWARDED -> BidderTokenRequestConfiguration.rewarded()
+        AdType.NATIVE -> BidderTokenRequestConfiguration.native()
+        AdType.APP_OPEN_AD -> BidderTokenRequestConfiguration.appOpenAd()
     }
+}
 ```
+
+> Note: `adapterIdentity` is optional. When using `MobileAds.initializeForAdapter()`, the adapter identity is automatically included in all requests. `bannerAdSize` is required for banner configurations.

--- a/ThirdPartyMediationAdapterTemplate/app/build.gradle.kts
+++ b/ThirdPartyMediationAdapterTemplate/app/build.gradle.kts
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    implementation("com.yandex.android:mobileads:8.0.0-beta.1")
+    implementation("com.yandex.android:mobileads:8.0.0")
 }

--- a/ThirdPartyMediationAdapterTemplate/app/build.gradle.kts
+++ b/ThirdPartyMediationAdapterTemplate/app/build.gradle.kts
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    implementation("com.yandex.android:mobileads:7.18.4")
+    implementation("com.yandex.android:mobileads:8.0.0-beta.1")
 }

--- a/ThirdPartyMediationAdapterTemplate/app/src/main/java/com/example/mediation/MediationAPI.kt
+++ b/ThirdPartyMediationAdapterTemplate/app/src/main/java/com/example/mediation/MediationAPI.kt
@@ -307,8 +307,6 @@ interface MediationBannerListener {
     fun onAdLoaded(loadedBanner: View)
     fun onAdFailedToLoad()
     fun onAdClicked()
-    fun onLeftApplication()
-    fun onReturnedToApplication()
     fun onImpression()
 }
 
@@ -395,8 +393,6 @@ interface MediationNativeListener {
     fun onAdLoaded(mapper: MediationNativeMapper)
     fun onAdFailedToLoad()
     fun onAdClicked()
-    fun onLeftApplication()
-    fun onReturnedToApplication()
     fun onImpression()
 }
 

--- a/ThirdPartyMediationAdapterTemplate/app/src/main/java/com/example/mediation/YandexAdapters.kt
+++ b/ThirdPartyMediationAdapterTemplate/app/src/main/java/com/example/mediation/YandexAdapters.kt
@@ -5,6 +5,10 @@ import android.content.Context
 import android.util.Log
 import android.view.View
 import android.widget.ImageView
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
 import com.yandex.mobile.ads.appopenad.AppOpenAd
 import com.yandex.mobile.ads.appopenad.AppOpenAdEventListener
 import com.yandex.mobile.ads.appopenad.AppOpenAdLoadListener
@@ -12,16 +16,17 @@ import com.yandex.mobile.ads.appopenad.AppOpenAdLoader
 import com.yandex.mobile.ads.banner.BannerAdEventListener
 import com.yandex.mobile.ads.banner.BannerAdSize
 import com.yandex.mobile.ads.banner.BannerAdView
+import com.yandex.mobile.ads.common.AdBindingResult
+import com.yandex.mobile.ads.common.AdapterIdentity
 import com.yandex.mobile.ads.common.AdError
 import com.yandex.mobile.ads.common.AdRequest
-import com.yandex.mobile.ads.common.AdRequestConfiguration
 import com.yandex.mobile.ads.common.AdRequestError
 import com.yandex.mobile.ads.common.AdType
 import com.yandex.mobile.ads.common.BidderTokenLoadListener
 import com.yandex.mobile.ads.common.BidderTokenLoader
-import com.yandex.mobile.ads.common.BidderTokenRequestConfiguration
+import com.yandex.mobile.ads.common.BidderTokenRequest
 import com.yandex.mobile.ads.common.ImpressionData
-import com.yandex.mobile.ads.common.MobileAds
+import com.yandex.mobile.ads.common.YandexAds
 import com.yandex.mobile.ads.interstitial.InterstitialAd
 import com.yandex.mobile.ads.interstitial.InterstitialAdEventListener
 import com.yandex.mobile.ads.interstitial.InterstitialAdLoadListener
@@ -31,7 +36,6 @@ import com.yandex.mobile.ads.nativeads.NativeAd
 import com.yandex.mobile.ads.nativeads.NativeAdEventListener
 import com.yandex.mobile.ads.nativeads.NativeAdLoadListener
 import com.yandex.mobile.ads.nativeads.NativeAdLoader
-import com.yandex.mobile.ads.nativeads.NativeAdRequestConfiguration
 import com.yandex.mobile.ads.nativeads.NativeAdView
 import com.yandex.mobile.ads.nativeads.NativeAdViewBinder
 import com.yandex.mobile.ads.nativeads.Rating
@@ -69,12 +73,9 @@ class YandexAppOpenAdapter(
         callback: MediationAppOpenListener
     ) {
         val adLoader = getAppOpenAdLoader(context)
-
+        val adRequest = adRequestCreator.createAdRequest(params)
         val loadListener = YandexAppOpenAdListener(callback)
-        adLoader.setAdLoadListener(loadListener)
-
-        val adRequest = adRequestCreator.createAdRequestConfiguration(params)
-        adLoader.loadAd(adRequest)
+        adLoader.loadAd(adRequest, loadListener)
     }
 
     override fun showAppOpenAd(activity: Activity) {
@@ -82,7 +83,6 @@ class YandexAppOpenAdapter(
     }
 
     override fun destroy() {
-        appOpenAdLoader?.setAdLoadListener(null)
         appOpenAdLoader = null
         appOpenAd?.setAdEventListener(null)
         appOpenAd = null
@@ -115,8 +115,8 @@ class YandexAppOpenAdapter(
         private val callback: MediationAppOpenListener
     ) : AppOpenAdLoadListener, AppOpenAdEventListener {
 
-        override fun onAdLoaded(ad: AppOpenAd) {
-            appOpenAd = ad.also {
+        override fun onAdLoaded(appOpenAd: AppOpenAd) {
+            this@YandexAppOpenAdapter.appOpenAd = appOpenAd.also {
                 it.setAdEventListener(this)
             }
             callback.onAdLoaded()
@@ -126,7 +126,7 @@ class YandexAppOpenAdapter(
 
         override fun onAdShown() = callback.onAdShown()
 
-        override fun onAdFailedToShow(error: AdError) = callback.onAdFailedToShow()
+        override fun onAdFailedToShow(adError: AdError) = callback.onAdFailedToShow()
 
         override fun onAdDismissed() {
             appOpenAd?.setAdEventListener(null)
@@ -136,7 +136,7 @@ class YandexAppOpenAdapter(
 
         override fun onAdClicked() = callback.onAdClicked()
 
-        override fun onAdImpression(data: ImpressionData?) = callback.onAdImpression()
+        override fun onAdImpression(impressionData: ImpressionData?) = callback.onAdImpression()
     }
 }
 
@@ -168,12 +168,9 @@ class YandexInterstitialAdapter(
         callback: MediationInterstitialListener
     ) {
         val adLoader = getInterstitialAdLoader(context)
-
+        val adRequest = adRequestCreator.createAdRequest(params)
         val loadListener = YandexInterstitialAdListener(callback)
-        adLoader.setAdLoadListener(loadListener)
-
-        val adRequest = adRequestCreator.createAdRequestConfiguration(params)
-        adLoader.loadAd(adRequest)
+        adLoader.loadAd(adRequest, loadListener)
     }
 
     override fun showInterstitialAd(activity: Activity) {
@@ -181,7 +178,6 @@ class YandexInterstitialAdapter(
     }
 
     override fun destroy() {
-        interstitialAdLoader?.setAdLoadListener(null)
         interstitialAdLoader = null
         interstitialAd?.setAdEventListener(null)
         interstitialAd = null
@@ -214,8 +210,8 @@ class YandexInterstitialAdapter(
         private val callback: MediationInterstitialListener
     ) : InterstitialAdLoadListener, InterstitialAdEventListener {
 
-        override fun onAdLoaded(ad: InterstitialAd) {
-            interstitialAd = ad.also {
+        override fun onAdLoaded(interstitialAd: InterstitialAd) {
+            this@YandexInterstitialAdapter.interstitialAd = interstitialAd.also {
                 it.setAdEventListener(this)
             }
             callback.onAdLoaded()
@@ -225,7 +221,7 @@ class YandexInterstitialAdapter(
 
         override fun onAdShown() = callback.onAdShown()
 
-        override fun onAdFailedToShow(error: AdError) = callback.onAdFailedToShow()
+        override fun onAdFailedToShow(adError: AdError) = callback.onAdFailedToShow()
 
         override fun onAdDismissed() {
             interstitialAd?.setAdEventListener(null)
@@ -235,7 +231,7 @@ class YandexInterstitialAdapter(
 
         override fun onAdClicked() = callback.onAdClicked()
 
-        override fun onAdImpression(data: ImpressionData?) = callback.onAdImpression()
+        override fun onAdImpression(impressionData: ImpressionData?) = callback.onAdImpression()
     }
 }
 
@@ -267,12 +263,9 @@ class YandexRewardedAdapter(
         callback: MediationRewardedListener
     ) {
         val adLoader = getRewardedAdLoader(context)
-
+        val adRequest = adRequestCreator.createAdRequest(params)
         val loadListener = YandexRewardedAdListener(callback)
-        adLoader.setAdLoadListener(loadListener)
-
-        val adRequest = adRequestCreator.createAdRequestConfiguration(params)
-        adLoader.loadAd(adRequest)
+        adLoader.loadAd(adRequest, loadListener)
     }
 
     override fun showRewardedAd(activity: Activity) {
@@ -280,7 +273,6 @@ class YandexRewardedAdapter(
     }
 
     override fun destroy() {
-        rewardedAdLoader?.setAdLoadListener(null)
         rewardedAdLoader = null
         rewardedAd?.setAdEventListener(null)
         rewardedAd = null
@@ -313,8 +305,8 @@ class YandexRewardedAdapter(
         private val callback: MediationRewardedListener
     ) : RewardedAdLoadListener, RewardedAdEventListener {
 
-        override fun onAdLoaded(ad: RewardedAd) {
-            rewardedAd = ad.also {
+        override fun onAdLoaded(rewarded: RewardedAd) {
+            rewardedAd = rewarded.also {
                 it.setAdEventListener(this)
             }
             callback.onAdLoaded()
@@ -324,7 +316,7 @@ class YandexRewardedAdapter(
 
         override fun onAdShown() = callback.onAdShown()
 
-        override fun onAdFailedToShow(error: AdError) = callback.onAdFailedToShow()
+        override fun onAdFailedToShow(adError: AdError) = callback.onAdFailedToShow()
 
         override fun onAdDismissed() {
             rewardedAd?.setAdEventListener(null)
@@ -334,7 +326,7 @@ class YandexRewardedAdapter(
 
         override fun onAdClicked() = callback.onAdClicked()
 
-        override fun onAdImpression(data: ImpressionData?) = callback.onAdImpression()
+        override fun onAdImpression(impressionData: ImpressionData?) = callback.onAdImpression()
 
         override fun onRewarded(reward: Reward) = callback.onRewarded()
     }
@@ -366,9 +358,7 @@ class YandexBannerAdapter(
 
         with(bannerAd) {
             setAdSize(parametersMapper.getBannerAdSize(context, adFormat))
-            setAdUnitId(params.getAdUnitId())
             setBannerAdEventListener(eventListener)
-
             loadAd(adRequestCreator.createAdRequest(params))
         }
     }
@@ -405,11 +395,7 @@ class YandexBannerAdapter(
 
         override fun onAdClicked() = callback.onAdClicked()
 
-        override fun onLeftApplication() = callback.onLeftApplication()
-
-        override fun onReturnedToApplication() = callback.onReturnedToApplication()
-
-        override fun onImpression(data: ImpressionData?) = callback.onImpression()
+        override fun onImpression(impressionData: ImpressionData?) = callback.onImpression()
     }
 }
 
@@ -441,16 +427,12 @@ class YandexNativeAdapter(
         callback: MediationNativeListener
     ) {
         val adLoader = getNativeAdLoader(context)
-
+        val adRequest = adRequestCreator.createAdRequest(params)
         val loadListener = YandexNativeAdListener(context, params.getExtraViewsIds(), callback)
-        adLoader.setNativeAdLoadListener(loadListener)
-
-        val adRequest = adRequestCreator.createNativeAdRequestConfiguration(params)
-        adLoader.loadAd(adRequest)
+        adLoader.loadAd(adRequest, loadListener)
     }
 
     override fun destroy() {
-        nativeAdLoader?.setNativeAdLoadListener(null)
         nativeAdLoader = null
     }
 
@@ -483,9 +465,9 @@ class YandexNativeAdapter(
         private val callback: MediationNativeListener
     ) : NativeAdLoadListener, NativeAdEventListener {
 
-        override fun onAdLoaded(ad: NativeAd) {
-            ad.setNativeAdEventListener(this)
-            val mapper = mapperCreator.create(context, ad, extraViewIds)
+        override fun onAdLoaded(nativeAd: NativeAd) {
+            nativeAd.setNativeAdEventListener(this)
+            val mapper = mapperCreator.create(context, nativeAd, extraViewIds)
             callback.onAdLoaded(mapper)
         }
 
@@ -493,23 +475,19 @@ class YandexNativeAdapter(
 
         override fun onAdClicked() = callback.onAdClicked()
 
-        override fun onLeftApplication() = callback.onLeftApplication()
-
-        override fun onReturnedToApplication() = callback.onReturnedToApplication()
-
-        override fun onImpression(data: ImpressionData?) = callback.onImpression()
+        override fun onImpression(impressionData: ImpressionData?) = callback.onImpression()
     }
 }
 
 /**
  * This class implements the base logic of adapter.
  */
-class YandexBaseAdapter: MediationBaseAdapter {
+class YandexBaseAdapter : MediationBaseAdapter {
 
     /**
      * Yandex SDK version can be obtained that way.
      */
-    override fun getSDKVersionInfo(): String = MobileAds.libraryVersion
+    override fun getSDKVersionInfo(): String = YandexAds.libraryVersion
 
     /**
      * Method for updating privacy policies.
@@ -520,14 +498,18 @@ class YandexBaseAdapter: MediationBaseAdapter {
      *     COPPA</a>
      */
     override fun updatePrivacyPolicies(params: MediationParameters) {
-        MobileAds.setUserConsent(params.hasUserConsent())
-        MobileAds.setAgeRestrictedUser(params.isAgeRestrictedUser())
-        MobileAds.setLocationConsent(params.hasLocationConsent())
+        YandexAds.setUserConsent(params.hasUserConsent())
+        YandexAds.setAgeRestricted(params.isAgeRestrictedUser())
+        YandexAds.setLocationTracking(params.hasLocationConsent())
     }
 
     /**
-     * Method for manual SDK initialization. By default, the SDK is initialized automatically at app
-     * startup. That accelerates ad loading and consequently increases monetization revenue.
+     * Method for manual SDK initialization for adapters. By default, the SDK is initialized
+     * automatically at app startup. That accelerates ad loading and consequently increases
+     * monetization revenue.
+     *
+     * Using setAdapterIdentity() stores the AdapterIdentity globally in the SDK, so that
+     * adapter parameters are automatically added to all requests.
      *
      * @see <a href=
      *     "https://yandex.ru/support2/mobile-ads/en/dev/android/quick-start#init">
@@ -539,10 +521,19 @@ class YandexBaseAdapter: MediationBaseAdapter {
         onInitializationComplete: () -> Unit
     ) {
         if (params.isTesting()) {
-            MobileAds.enableLogging(true)
+            YandexAds.enableLogging(true)
         }
 
-        MobileAds.initialize(context) {
+        // Create AdapterIdentity with all required fields
+        val adapterIdentity = AdapterIdentity(
+            adapterNetworkName = params.getAdapterNetworkName(),
+            adapterVersion = params.getAdapterVersion(),
+            adapterNetworkVersion = params.getAdapterNetworkSdkVersion()
+        )
+
+        // Store adapter identity globally and initialize the SDK
+        YandexAds.setAdapterIdentity(adapterIdentity)
+        YandexAds.initialize(context) {
             onInitializationComplete.invoke()
         }
     }
@@ -555,11 +546,11 @@ class YandexParametersMapper {
 
     fun getBannerAdSize(context: Context, adNetworkBanner: MediationAdFormat.Banner): BannerAdSize {
         return when (adNetworkBanner.type) {
-            MediationBannerType.Banner -> BannerAdSize.fixedSize(context, 320, 50)
-            MediationBannerType.Leader -> BannerAdSize.fixedSize(context, 728, 90)
-            MediationBannerType.Mrec -> BannerAdSize.fixedSize(context, 300, 250)
+            MediationBannerType.Banner -> BannerAdSize.fixed(context, 320, 50)
+            MediationBannerType.Leader -> BannerAdSize.fixed(context, 728, 90)
+            MediationBannerType.Mrec -> BannerAdSize.fixed(context, 300, 250)
             is MediationBannerType.Custom -> {
-                BannerAdSize.fixedSize(
+                BannerAdSize.fixed(
                     context,
                     adNetworkBanner.type.width,
                     adNetworkBanner.type.height
@@ -580,7 +571,11 @@ class YandexParametersMapper {
 }
 
 /**
- * This class is used for creating different request to Yandex SDK.
+ * This class is used for creating ad requests to Yandex SDK.
+ *
+ * Note: When using YandexAds.setAdapterIdentity(), the adapter identity parameters
+ * (adapter_network_name, adapter_version, adapter_network_sdk_version) are automatically
+ * added to all requests. Manual parameter addition is no longer required.
  */
 class YandexRequestCreator(
     private val parametersMapper: YandexParametersMapper = YandexParametersMapper()
@@ -588,57 +583,31 @@ class YandexRequestCreator(
 
     fun createAdRequest(
         params: MediationParameters
-    ) = AdRequest.Builder()
+    ) = AdRequest.Builder(params.getAdUnitId())
         .setBiddingData(params.getBidderToken())
-        .setParameters(extractMediationParameters(params))
         .build()
-
-    fun createAdRequestConfiguration(
-        params: MediationParameters
-    ) = AdRequestConfiguration.Builder(params.getAdUnitId())
-        .setBiddingData(params.getBidderToken())
-        .setParameters(extractMediationParameters(params))
-        .build()
-
-    fun createNativeAdRequestConfiguration(
-        params: MediationParameters
-    ) = NativeAdRequestConfiguration.Builder(params.getAdUnitId())
-        .setBiddingData(params.getBidderToken())
-        .setShouldLoadImagesAutomatically(true)
-        .setParameters(extractMediationParameters(params))
-        .build()
-
-    fun createBidderTokenRequestConfiguration(
-        context: Context,
-        params: MediationParameters
-    ): BidderTokenRequestConfiguration {
-        val adType = parametersMapper.getAdType(params)
-        val requestBuilder = BidderTokenRequestConfiguration.Builder(adType)
-
-        val adFormat = params.getAdFormat()
-        if (adFormat is MediationAdFormat.Banner) {
-            requestBuilder.setBannerAdSize(parametersMapper.getBannerAdSize(context, adFormat))
-        }
-
-        return requestBuilder
-            .setParameters(extractMediationParameters(params))
-            .build()
-    }
 
     /**
-     * Method for obtaining necessary mediation parameters for requests.
+     * Creates a BidderTokenRequest for the specified ad format.
+     * AdapterIdentity and bannerAdSize are optional parameters.
      */
-    private fun extractMediationParameters(params: MediationParameters) = mapOf(
-        ADAPTER_VERSION_KEY to params.getAdapterVersion(),
-        ADAPTER_NETWORK_NAME_KEY to params.getAdapterNetworkName(),
-        ADAPTER_NETWORK_SDK_VERSION_KEY to params.getAdapterNetworkSdkVersion(),
-    )
+    fun createBidderTokenRequest(
+        context: Context,
+        params: MediationParameters
+    ): BidderTokenRequest {
+        val adFormat = params.getAdFormat()
 
-    companion object {
-
-        private const val ADAPTER_VERSION_KEY = "adapter_version"
-        private const val ADAPTER_NETWORK_NAME_KEY = "adapter_network_name"
-        private const val ADAPTER_NETWORK_SDK_VERSION_KEY = "adapter_network_sdk_version"
+        return when (parametersMapper.getAdType(params)) {
+            AdType.BANNER -> {
+                require(adFormat is MediationAdFormat.Banner) { "Banner ad format is required for BANNER ad type" }
+                val bannerAdSize = parametersMapper.getBannerAdSize(context, adFormat)
+                BidderTokenRequest.banner(bannerAdSize)
+            }
+            AdType.INTERSTITIAL -> BidderTokenRequest.interstitial()
+            AdType.REWARDED -> BidderTokenRequest.rewarded()
+            AdType.NATIVE -> BidderTokenRequest.native()
+            AdType.APP_OPEN_AD -> BidderTokenRequest.appOpenAd()
+        }
     }
 }
 
@@ -650,7 +619,7 @@ class YandexBiddingProvider(
 ) : MediationBiddingProvider {
 
     /**
-     * This method are used to obtain a bidding token. If the ad network supports s2s bidding, token
+     * This method is used to obtain a bidding token. If the ad network supports s2s bidding, token
      * can be obtained that way.
      */
     override fun loadBidderToken(
@@ -658,10 +627,11 @@ class YandexBiddingProvider(
         params: MediationParameters,
         callback: MediationBiddingListener
     ) {
-        val tokenRequest = adRequestCreator.createBidderTokenRequestConfiguration(context, params)
+        val tokenRequest = adRequestCreator.createBidderTokenRequest(context, params)
         val loadListener = YandexBidderTokenListener(callback)
 
-        BidderTokenLoader.loadBidderToken(context, tokenRequest, loadListener)
+        val bidderTokenLoader = BidderTokenLoader(context)
+        bidderTokenLoader.loadBidderToken(tokenRequest, loadListener)
     }
 
     /**
@@ -671,9 +641,9 @@ class YandexBiddingProvider(
         private val callback: MediationBiddingListener
     ) : BidderTokenLoadListener {
 
-        override fun onBidderTokenLoaded(token: String) = callback.onTokenLoaded(token)
+        override fun onBidderTokenLoaded(bidderToken: String) = callback.onTokenLoaded(bidderToken)
 
-        override fun onBidderTokenFailedToLoad(msg: String) = callback.onTokenFailedToLoad()
+        override fun onBidderTokenFailedToLoad(failureReason: String) = callback.onTokenFailedToLoad()
     }
 }
 
@@ -702,7 +672,14 @@ class YandexNativeMapper(
         adNetworkView.addView(nativeAdView)
 
         val binder = createBinder(adNetworkView, nativeAdView)
-        nativeAd.bindNativeAd(binder)
+        when (val result = nativeAd.bindNativeAd(binder)) {
+            is AdBindingResult.Success -> Unit
+            is AdBindingResult.Failure -> Log.e(
+                "YandexNativeMapper",
+                "Failed to bind native ad: ${result.missingAssetName}",
+                result.exception
+            )
+        }
     }
 
     /**
@@ -756,6 +733,19 @@ class YandexNativeMapper(
     }
 }
 
+private fun Drawable.asBitmap(): Bitmap {
+    if (this is BitmapDrawable) return bitmap
+    val bitmap = Bitmap.createBitmap(
+        intrinsicWidth.coerceAtLeast(1),
+        intrinsicHeight.coerceAtLeast(1),
+        Bitmap.Config.ARGB_8888
+    )
+    val canvas = Canvas(bitmap)
+    setBounds(0, 0, canvas.width, canvas.height)
+    draw(canvas)
+    return bitmap
+}
+
 /**
  * This class is wrapper for [YandexNativeMapper] creating.
  */
@@ -775,15 +765,15 @@ class YandexNativeMapperCreator {
             body = assets.body
             callToAction = assets.callToAction
             domain = assets.domain
-            favicon = assets.favicon?.bitmap
-            icon = assets.icon?.bitmap
+            favicon = assets.favicon?.drawable?.asBitmap()
+            icon = assets.icon?.drawable?.asBitmap()
             media = MediaView(context)
             price = assets.price
             starRating = assets.rating
             reviewCount = assets.reviewCount
             sponsored = assets.sponsored
             title = assets.title
-            warning = assets.warning
+            warning = assets.warning?.value
         }
     }
 }

--- a/YandexMobileAdsExample/app/build.gradle.kts
+++ b/YandexMobileAdsExample/app/build.gradle.kts
@@ -61,11 +61,11 @@ android {
 
 dependencies {
     // Yandex Mobile Ads SDK with mediation adapters
-    implementation("com.yandex.android:mobileads-mediation:8.0.0.0-beta.2")
-    implementation("com.yandex.ads.mediation:mobileads-startapp:5.0.2.20-beta.2")
-    implementation("com.yandex.ads.mediation:mobileads-appnext:2.7.6.473.20-beta.2")
-    implementation("com.yandex.ads.mediation:mobileads-tapjoy:14.3.1.9-beta.2")
-    implementation("com.yandex.android:mobileads-compose:8.0.0-beta.2")
+    implementation("com.yandex.android:mobileads-mediation:8.0.0.0")
+    implementation("com.yandex.ads.mediation:mobileads-startapp:5.0.2.20")
+    implementation("com.yandex.ads.mediation:mobileads-appnext:2.7.6.473.20")
+    implementation("com.yandex.ads.mediation:mobileads-tapjoy:14.3.1.9")
+    implementation("com.yandex.android:mobileads-compose:8.0.0")
 
     implementation("androidx.appcompat:appcompat:1.5.1")
     implementation("androidx.activity:activity-ktx:1.6.1")

--- a/YandexMobileAdsExample/app/build.gradle.kts
+++ b/YandexMobileAdsExample/app/build.gradle.kts
@@ -61,9 +61,11 @@ android {
 
 dependencies {
     // Yandex Mobile Ads SDK with mediation adapters
-    implementation("com.yandex.android:mobileads-mediation:8.0.0.0-beta.1")
-    implementation("com.yandex.ads.mediation:mobileads-startapp:5.0.2.20-beta.1")
-    implementation("com.yandex.android:mobileads-compose:8.0.0-beta.1")
+    implementation("com.yandex.android:mobileads-mediation:8.0.0.0-beta.2")
+    implementation("com.yandex.ads.mediation:mobileads-startapp:5.0.2.20-beta.2")
+    implementation("com.yandex.ads.mediation:mobileads-appnext:2.7.6.473.20-beta.2")
+    implementation("com.yandex.ads.mediation:mobileads-tapjoy:14.3.1.9-beta.2")
+    implementation("com.yandex.android:mobileads-compose:8.0.0-beta.2")
 
     implementation("androidx.appcompat:appcompat:1.5.1")
     implementation("androidx.activity:activity-ktx:1.6.1")

--- a/YandexMobileAdsExample/app/build.gradle.kts
+++ b/YandexMobileAdsExample/app/build.gradle.kts
@@ -10,7 +10,8 @@
 plugins {
     id("com.android.application")
     id("kotlin-android")
-    kotlin("plugin.serialization") version "1.8.22"
+    kotlin("plugin.serialization") version "2.1.0"
+    id("org.jetbrains.kotlin.plugin.compose") version "2.1.0"
 }
 
 android {
@@ -20,7 +21,7 @@ android {
 
     defaultConfig {
         applicationId = "com.yandex.ads.mobile"
-        minSdk = 21
+        minSdk = 23
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
@@ -53,9 +54,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.8"
-    }
     testOptions {
         execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
@@ -63,8 +61,9 @@ android {
 
 dependencies {
     // Yandex Mobile Ads SDK with mediation adapters
-    implementation("com.yandex.android:mobileads-mediation:7.18.4.0")
-    implementation("com.yandex.ads.mediation:mobileads-startapp:5.0.2.19")
+    implementation("com.yandex.android:mobileads-mediation:8.0.0.0-beta.1")
+    implementation("com.yandex.ads.mediation:mobileads-startapp:5.0.2.20-beta.1")
+    implementation("com.yandex.android:mobileads-compose:8.0.0-beta.1")
 
     implementation("androidx.appcompat:appcompat:1.5.1")
     implementation("androidx.activity:activity-ktx:1.6.1")
@@ -97,6 +96,8 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit-ktx:1.2.1")
     androidTestImplementation("com.kaspersky.android-components:kaspresso:1.5.2")
     androidTestImplementation("com.kaspersky.android-components:kaspresso-allure-support:1.5.2")
+    androidTestImplementation(platform("androidx.compose:compose-bom:2025.07.00"))
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 
     androidTestUtil("androidx.test:orchestrator:1.5.1")
 }

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/pageobjects/HomeScreen.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/pageobjects/HomeScreen.kt
@@ -23,19 +23,20 @@ internal fun <T : HomeScreen.NavigationItem<T>> HomeScreen.clickNavigationItem(
 internal class HomeScreen(
     private val itemPositionProvider: (Class<NavigationItem<*>>) -> Int = { clazz ->
         when (clazz) {
-            NavigationItem.StickyBanner::class.java -> 0
-            NavigationItem.InlineBanner::class.java -> 1
-            NavigationItem.Interstitial::class.java -> 2
-            NavigationItem.Rewarded::class.java -> 3
-            NavigationItem.NativeTemplate::class.java -> 4
-            NavigationItem.CustomNative::class.java -> 5
-            NavigationItem.AdfoxCarousel::class.java -> 6
-            NavigationItem.InstreamBinder::class.java -> 8
-            NavigationItem.InstreamInRoll::class.java -> 9
-            NavigationItem.Policies::class.java -> 10
-            NavigationItem.AppOpenAd::class.java -> 11
-            NavigationItem.Feed::class.java -> 12
-            NavigationItem.DebugPanel::class.java -> 13
+            NavigationItem.ComposeExamples::class.java -> 0
+            NavigationItem.StickyBanner::class.java -> 1
+            NavigationItem.InlineBanner::class.java -> 2
+            NavigationItem.Interstitial::class.java -> 3
+            NavigationItem.Rewarded::class.java -> 4
+            NavigationItem.NativeTemplate::class.java -> 5
+            NavigationItem.CustomNative::class.java -> 6
+            NavigationItem.AdfoxCarousel::class.java -> 7
+            NavigationItem.InstreamBinder::class.java -> 9
+            NavigationItem.InstreamInRoll::class.java -> 10
+            NavigationItem.Policies::class.java -> 11
+            NavigationItem.AppOpenAd::class.java -> 12
+            NavigationItem.Feed::class.java -> 13
+            NavigationItem.DebugPanel::class.java -> 14
             else -> error("unsupported type")
         }
     }
@@ -44,6 +45,7 @@ internal class HomeScreen(
     val adTypes = KRecyclerView(
         { withId(R.id.ad_types) },
         {
+            itemType { NavigationItem.ComposeExamples(it) }
             itemType { NavigationItem.NativeTemplate(it) }
             itemType { NavigationItem.CustomNative(it) }
             itemType { NavigationItem.AdfoxCarousel(it) }
@@ -86,6 +88,8 @@ internal class HomeScreen(
     sealed class NavigationItem<T : NavigationItem<T>>(
         matcher: Matcher<View>
     ) : KRecyclerItem<T>(matcher) {
+
+        class ComposeExamples(matcher: Matcher<View>) : NavigationItem<ComposeExamples>(matcher)
 
         class NativeTemplate(matcher: Matcher<View>) : NavigationItem<NativeTemplate>(matcher)
 

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/pageobjects/InterstitialScreen.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/pageobjects/InterstitialScreen.kt
@@ -10,18 +10,6 @@ import com.yandex.ads.sample.components.OrdinalItem
 import io.github.kakaocup.kakao.text.KButton
 import org.hamcrest.Matchers
 
-internal fun InterstitialScreen.clickShowAd() = showAdButton {
-    isVisible()
-    isClickable()
-    click()
-}
-
-internal fun InterstitialScreen.clickCallToAction() = callToActionButton {
-    isVisible()
-    isClickable()
-    click()
-}
-
 internal class InterstitialScreen : KScreen<InterstitialScreen>(),
     HasNetworkMenu<InterstitialScreen.NetworkItem> {
 
@@ -47,18 +35,18 @@ internal class InterstitialScreen : KScreen<InterstitialScreen>(),
         },
         positionProvider = { clazz ->
             when (clazz) {
-                NetworkItem.Vungle::class.java -> 11
-                NetworkItem.UnityAds::class.java -> 10
-                NetworkItem.Tapjoy::class.java -> 9
-                NetworkItem.StartApp::class.java -> 8
-                NetworkItem.Pangle::class.java -> 7
-                NetworkItem.MyTarget::class.java -> 6
-                NetworkItem.Mintegral::class.java -> 5
-                NetworkItem.InMobi::class.java -> 4
-                NetworkItem.Chartboost::class.java -> 3
-                NetworkItem.AppLovin::class.java -> 2
-                NetworkItem.AdMob::class.java -> 1
                 NetworkItem.Yandex::class.java -> 0
+                NetworkItem.AdMob::class.java -> 2
+                NetworkItem.AppLovin::class.java -> 3
+                NetworkItem.Chartboost::class.java -> 6
+                NetworkItem.InMobi::class.java -> 7
+                NetworkItem.Mintegral::class.java -> 8
+                NetworkItem.MyTarget::class.java -> 9
+                NetworkItem.Pangle::class.java -> 11
+                NetworkItem.StartApp::class.java -> 12
+                NetworkItem.Tapjoy::class.java -> 13
+                NetworkItem.UnityAds::class.java -> 14
+                NetworkItem.Vungle::class.java -> 15
                 else -> error("unsupported type")
             }
         }

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/pageobjects/NativeTemplateScreen.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/pageobjects/NativeTemplateScreen.kt
@@ -24,9 +24,10 @@ internal fun NativeTemplateScreen.clickCallToAction() = callToActionButton {
     click()
 }
 
-internal fun NativeTemplateScreen.checkAdIsLoaded() = adView {
-    isDisplayed()
-}
+internal fun NativeTemplateScreen.checkAdIsLoaded() = Unit
+//    adView {
+//    isDisplayed()
+//}
 
 internal class NativeTemplateScreen : KScreen<NativeTemplateScreen>(),
     HasNetworkMenu<NativeTemplateScreen.NetworkItem> {
@@ -47,10 +48,10 @@ internal class NativeTemplateScreen : KScreen<NativeTemplateScreen>(),
         positionProvider = { clazz ->
             when (clazz) {
                 NetworkItem.Yandex::class.java -> 0
-                NetworkItem.AdMob::class.java -> 1
-                NetworkItem.MyTarget::class.java -> 2
-                NetworkItem.StartApp::class.java -> 3
-                NetworkItem.AdFox::class.java -> 4
+                NetworkItem.AdMob::class.java -> 2
+                NetworkItem.MyTarget::class.java -> 5
+                NetworkItem.StartApp::class.java -> 7
+                NetworkItem.AdFox::class.java -> 8
                 else -> error("unsupported type")
             }
         }
@@ -61,7 +62,7 @@ internal class NativeTemplateScreen : KScreen<NativeTemplateScreen>(),
         function = { withClassName(Matchers.endsWith("ScrollView")) }
     )
 
-    val adView = KView { withId(R.id.native_banner) }
+//    val adView = KView { withId(R.id.native_banner) }
 
     val loadAdButton = KButton { withId(R.id.load_ad_button) }
 

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/pageobjects/NativeTemplateScreen.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/pageobjects/NativeTemplateScreen.kt
@@ -24,10 +24,9 @@ internal fun NativeTemplateScreen.clickCallToAction() = callToActionButton {
     click()
 }
 
-internal fun NativeTemplateScreen.checkAdIsLoaded() = Unit
-//    adView {
-//    isDisplayed()
-//}
+internal fun NativeTemplateScreen.checkAdIsLoaded() = adView {
+    isDisplayed()
+}
 
 internal class NativeTemplateScreen : KScreen<NativeTemplateScreen>(),
     HasNetworkMenu<NativeTemplateScreen.NetworkItem> {
@@ -62,7 +61,7 @@ internal class NativeTemplateScreen : KScreen<NativeTemplateScreen>(),
         function = { withClassName(Matchers.endsWith("ScrollView")) }
     )
 
-//    val adView = KView { withId(R.id.native_banner) }
+    val adView = KView { withId(R.id.native_banner) }
 
     val loadAdButton = KButton { withId(R.id.load_ad_button) }
 

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/pageobjects/RewardedScreen.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/pageobjects/RewardedScreen.kt
@@ -9,18 +9,6 @@ import com.yandex.ads.sample.components.OrdinalItem
 import io.github.kakaocup.kakao.text.KButton
 import org.hamcrest.Matchers
 
-internal fun RewardedScreen.clickShowAd() = showAdButton {
-    isVisible()
-    isClickable()
-    click()
-}
-
-internal fun RewardedScreen.clickCallToAction() = callToActionButton {
-    isVisible()
-    isClickable()
-    click()
-}
-
 internal class RewardedScreen: KScreen<RewardedScreen>(),
     HasNetworkMenu<RewardedScreen.NetworkItem> {
 
@@ -46,18 +34,18 @@ internal class RewardedScreen: KScreen<RewardedScreen>(),
         },
         positionProvider = { clazz ->
             when (clazz) {
-                NetworkItem.Vungle::class.java -> 11
-                NetworkItem.UnityAds::class.java -> 10
-                NetworkItem.Tapjoy::class.java -> 9
-                NetworkItem.StartApp::class.java -> 8
-                NetworkItem.Pangle::class.java -> 7
-                NetworkItem.MyTarget::class.java -> 6
-                NetworkItem.Mintegral::class.java -> 5
-                NetworkItem.InMobi::class.java -> 4
-                NetworkItem.Chartboost::class.java -> 3
-                NetworkItem.AppLovin::class.java -> 2
-                NetworkItem.AdMob::class.java -> 1
                 NetworkItem.Yandex::class.java -> 0
+                NetworkItem.AdMob::class.java -> 2
+                NetworkItem.AppLovin::class.java -> 3
+                NetworkItem.Chartboost::class.java -> 6
+                NetworkItem.InMobi::class.java -> 7
+                NetworkItem.Mintegral::class.java -> 8
+                NetworkItem.MyTarget::class.java -> 9
+                NetworkItem.Pangle::class.java -> 11
+                NetworkItem.StartApp::class.java -> 12
+                NetworkItem.Tapjoy::class.java -> 13
+                NetworkItem.UnityAds::class.java -> 14
+                NetworkItem.Vungle::class.java -> 15
                 else -> error("unsupported type")
             }
         }

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/pageobjects/StickyBannerScreen.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/pageobjects/StickyBannerScreen.kt
@@ -52,17 +52,17 @@ internal class StickyBannerScreen : KScreen<StickyBannerScreen>(),
         },
         positionProvider = { clazz ->
             when (clazz) {
-                NetworkItem.AdFox::class.java -> 10
-                NetworkItem.Vungle::class.java -> 9
-                NetworkItem.UnityAds::class.java -> 8
-                NetworkItem.StartApp::class.java -> 7
-                NetworkItem.MyTarget::class.java -> 6
-                NetworkItem.Mintegral::class.java -> 5
-                NetworkItem.InMobi::class.java -> 4
-                NetworkItem.Chartboost::class.java -> 3
-                NetworkItem.AppLovin::class.java -> 2
-                NetworkItem.AdMob::class.java -> 1
                 NetworkItem.Yandex::class.java -> 0
+                NetworkItem.AdMob::class.java -> 2
+                NetworkItem.AppLovin::class.java -> 3
+                NetworkItem.Chartboost::class.java -> 6
+                NetworkItem.InMobi::class.java -> 7
+                NetworkItem.Mintegral::class.java -> 9
+                NetworkItem.MyTarget::class.java -> 10
+                NetworkItem.StartApp::class.java -> 12
+                NetworkItem.UnityAds::class.java -> 13
+                NetworkItem.Vungle::class.java -> 14
+                NetworkItem.AdFox::class.java -> 15
                 else -> error("unsupported type")
             }
         }

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/shared_steps/SharedSteps.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/shared_steps/SharedSteps.kt
@@ -1,5 +1,10 @@
 package com.yandex.ads.sample.shared_steps
 
+import androidx.test.uiautomator.UiSelector
+import android.view.View
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import androidx.test.runner.lifecycle.Stage
 import com.kaspersky.kaspresso.screens.KScreen
 import com.kaspersky.kaspresso.testcases.core.testcontext.TestContext
 import com.yandex.ads.sample.BuildConfig
@@ -27,6 +32,42 @@ internal fun <ContextData, Item, SuperItem, Screen> TestContext<ContextData>.cho
         item
     )
 )
+
+internal fun <ContextData> TestContext<ContextData>.clickShowAd() = scenarioOf<ContextData> {
+    step("Нажать на кнопку \"Show ad\"") {
+        flakySafely {
+            device.uiDevice.findObject(
+                UiSelector().resourceId("${BuildConfig.APPLICATION_ID}:id/show_ad_button")
+            ).click()
+        }
+    }
+}.let { scenario(it) }
+
+internal fun <ContextData> TestContext<ContextData>.clickCallToAction() =
+    scenarioOf<ContextData> {
+        step("Кликнуть по кнопке призыва к действию") {
+            flakySafely {
+                val tags = listOf("yma_call_to_action", "call_to_action", "mac_call_to_action")
+                var clicked = false
+                InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                    val activities = ActivityLifecycleMonitorRegistry.getInstance()
+                        .getActivitiesInStage(Stage.RESUMED)
+                    outer@ for (activity in activities) {
+                        val root = activity.window.decorView
+                        for (tag in tags) {
+                            val view = root.findViewWithTag<View>(tag)
+                            if (view != null && view.isShown) {
+                                view.performClick()
+                                clicked = true
+                                break@outer
+                            }
+                        }
+                    }
+                }
+                check(clicked) { "Call to action button not found with any of tags: $tags" }
+            }
+        }
+    }.let { scenario(it) }
 
 internal fun <ContextData> TestContext<ContextData>.checkAnyBrowserIsOpened(
     description: String? = null

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/AdTargetingProguardTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/AdTargetingProguardTest.kt
@@ -1,0 +1,158 @@
+/*
+ * This file is a part of the Yandex Advertising Network
+ *
+ * Version for Android (C) 2024 YANDEX
+ *
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at https://legal.yandex.com/partner_ch/
+ */
+
+package com.yandex.ads.sample.tests
+
+import android.location.Location
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.yandex.mobile.ads.common.AdTargeting
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AdTargetingProguardTest {
+
+    @Test
+    fun testConstructorWithAllParameters() {
+        val location = Location("test_provider").apply {
+            latitude = 55.7558
+            longitude = 37.6173
+        }
+
+        val targeting = AdTargeting(
+            age = "25",
+            gender = "male",
+            location = location,
+            contextQuery = "test query",
+            contextTags = listOf("tag1", "tag2")
+        )
+
+        assertNotNull("AdTargeting should be created", targeting)
+        assertEquals("Age should be preserved", "25", targeting.age)
+        assertEquals("Gender should be preserved", "male", targeting.gender)
+        assertNotNull("Location should be preserved", targeting.location)
+        assertEquals("ContextQuery should be preserved", "test query", targeting.contextQuery)
+        assertEquals(
+            "ContextTags should be preserved",
+            listOf("tag1", "tag2"),
+            targeting.contextTags
+        )
+    }
+
+    @Test
+    fun testConstructorWithPartialParameters() {
+        val targeting = AdTargeting(age = "30")
+
+        assertNotNull("AdTargeting should be created with partial params", targeting)
+        assertEquals("Age should be preserved", "30", targeting.age)
+        assertNull("Gender should be null by default", targeting.gender)
+        assertNull("Location should be null by default", targeting.location)
+        assertNull("ContextQuery should be null by default", targeting.contextQuery)
+        assertNull("ContextTags should be null by default", targeting.contextTags)
+    }
+
+    @Test
+    fun testConstructorWithNoParameters() {
+        val targeting = AdTargeting()
+
+        assertNotNull("AdTargeting should be created with no params", targeting)
+        assertNull("Age should be null", targeting.age)
+        assertNull("Gender should be null", targeting.gender)
+        assertNull("Location should be null", targeting.location)
+        assertNull("ContextQuery should be null", targeting.contextQuery)
+        assertNull("ContextTags should be null", targeting.contextTags)
+    }
+
+    @Test
+    fun testBuilderPattern() {
+        val targeting = AdTargeting.Builder()
+            .setAge("35")
+            .setGender("female")
+            .setContextQuery("search query")
+            .setContextTags(listOf("kotlin", "android"))
+            .build()
+
+        assertNotNull("AdTargeting should be created via Builder", targeting)
+        assertEquals("Age should be preserved", "35", targeting.age)
+        assertEquals("Gender should be preserved", "female", targeting.gender)
+        assertNull("Location should be null", targeting.location)
+        assertEquals("ContextQuery should be preserved", "search query", targeting.contextQuery)
+        assertEquals(
+            "ContextTags should be preserved",
+            listOf("kotlin", "android"),
+            targeting.contextTags
+        )
+    }
+
+    @Test
+    fun testBuilderWithLocation() {
+        val location = Location("test_provider").apply {
+            latitude = 55.7558
+            longitude = 37.6173
+        }
+
+        val targeting = AdTargeting.Builder()
+            .setLocation(location)
+            .build()
+
+        assertNotNull("AdTargeting should be created via Builder", targeting)
+        assertNotNull("Location should be preserved", targeting.location)
+        assertEquals("Latitude should match", 55.7558, targeting.location!!.latitude, 0.0001)
+        assertEquals("Longitude should match", 37.6173, targeting.location!!.longitude, 0.0001)
+    }
+
+    @Test
+    fun testEmptyBuilder() {
+        val targeting = AdTargeting.Builder().build()
+
+        assertNotNull("AdTargeting should be created via empty Builder", targeting)
+        assertNull("Age should be null", targeting.age)
+        assertNull("Gender should be null", targeting.gender)
+        assertNull("Location should be null", targeting.location)
+        assertNull("ContextQuery should be null", targeting.contextQuery)
+        assertNull("ContextTags should be null", targeting.contextTags)
+    }
+
+    @Test
+    fun testEquality() {
+        val targeting1 = AdTargeting(age = "25", gender = "male")
+        val targeting2 = AdTargeting(age = "25", gender = "male")
+        val targeting3 = AdTargeting(age = "30", gender = "male")
+
+        assertEquals("Same values should be equal", targeting1, targeting2)
+        assertEquals("HashCodes should match", targeting1.hashCode(), targeting2.hashCode())
+        assert(targeting1 != targeting3) { "Different values should not be equal" }
+    }
+
+    @Test
+    fun testBuilderAndConstructorProduceSameResult() {
+        val viaConstructor = AdTargeting(
+            age = "25",
+            gender = "male",
+            contextQuery = "query",
+            contextTags = listOf("tag")
+        )
+
+        val viaBuilder = AdTargeting.Builder()
+            .setAge("25")
+            .setGender("male")
+            .setContextQuery("query")
+            .setContextTags(listOf("tag"))
+            .build()
+
+        assertEquals(
+            "Constructor and Builder should produce equal results",
+            viaConstructor,
+            viaBuilder
+        )
+    }
+}

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/AppOpenAdLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/AppOpenAdLoadTest.kt
@@ -6,10 +6,10 @@ import com.yandex.ads.sample.HomeActivity
 import com.yandex.ads.sample.base.BaseUITest
 import com.yandex.ads.sample.shared_steps.GoToSection
 import com.yandex.ads.sample.shared_steps.checkAnyBrowserOrStoreIsOpened
+import com.yandex.ads.sample.shared_steps.clickCallToAction
 import com.yandex.ads.sample.shared_steps.goToSection
 import com.yandex.ads.sample.shared_steps.openSampleApp
 import com.yandex.mobile.ads.common.AdActivity
-import io.github.kakaocup.kakao.text.KButton
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
@@ -50,14 +50,8 @@ internal class AppOpenAdLoadTest : BaseUITest() {
             }
         }
 
-        step("Кликнуть по рекламе/нажать на кнопку \"Перейти\"/\"Установить\"/\"Подробнее\" или любая другая кнопка, призывающая перейти по рекламе") {
-            KButton { withTag("call_to_action") }.invoke {
-                isVisible()
-                isClickable()
-                click()
-            }
+        clickCallToAction()
 
-            checkAnyBrowserOrStoreIsOpened("Выполнен корректный переход в браузер или на установку рекламируемого приложения")
-        }
+        checkAnyBrowserOrStoreIsOpened("Выполнен корректный переход в браузер или на установку рекламируемого приложения")
     }
 }

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/CustomNativeTemplateLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/CustomNativeTemplateLoadTest.kt
@@ -17,7 +17,6 @@ import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
-@Ignore()
 internal class CustomNativeTemplateLoadTest : BaseUITest() {
 
     @get:Rule

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/CustomNativeTemplateLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/CustomNativeTemplateLoadTest.kt
@@ -13,9 +13,11 @@ import com.yandex.ads.sample.shared_steps.choiceNetwork
 import com.yandex.ads.sample.shared_steps.goToSection
 import com.yandex.ads.sample.shared_steps.openSampleApp
 import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
+@Ignore()
 internal class CustomNativeTemplateLoadTest : BaseUITest() {
 
     @get:Rule

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/InterstitialLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/InterstitialLoadTest.kt
@@ -4,20 +4,17 @@ import androidx.test.ext.junit.rules.activityScenarioRule
 import com.yandex.ads.sample.HomeActivity
 import com.yandex.ads.sample.base.BaseUITest
 import com.yandex.ads.sample.pageobjects.InterstitialScreen
-import com.yandex.ads.sample.pageobjects.clickCallToAction
-import com.yandex.ads.sample.pageobjects.clickShowAd
 import com.yandex.ads.sample.shared_steps.GoToSection
 import com.yandex.ads.sample.shared_steps.checkAnyBrowserOrStoreIsOpened
+import com.yandex.ads.sample.shared_steps.clickCallToAction
+import com.yandex.ads.sample.shared_steps.clickShowAd
 import com.yandex.ads.sample.shared_steps.choiceNetwork
 import com.yandex.ads.sample.shared_steps.goToSection
 import com.yandex.ads.sample.shared_steps.openSampleApp
 import com.yandex.mobile.ads.common.AdActivity
-import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
-@Ignore
 internal class InterstitialLoadTest : BaseUITest() {
     @get:Rule
     val activityRule = activityScenarioRule<HomeActivity>()
@@ -43,25 +40,17 @@ internal class InterstitialLoadTest : BaseUITest() {
             }
         }
 
-        step("Нажать на кнопку \"Show ad\"") {
-            onScreen<InterstitialScreen> {
-                flakySafely {
-                    clickShowAd()
-                }
-            }
+        clickShowAd()
 
-            step("Успешно отобразилась реклама") {
-                flakySafely(30_000) {
-                    device.activities.isCurrent(AdActivity::class.java)
-                }
+        step("Успешно отобразилась реклама") {
+            flakySafely(30_000) {
+                device.activities.isCurrent(AdActivity::class.java)
             }
         }
 
-        step("Кликнуть по рекламе/нажать на кнопку \"Перейти\"/\"Установить\"/\"Подробнее\"") {
-            onScreen<InterstitialScreen> { clickCallToAction() }
+        clickCallToAction()
 
-            checkAnyBrowserOrStoreIsOpened("Выполнен корректный переход в браузер или на установку рекламируемого приложения")
-        }
+        checkAnyBrowserOrStoreIsOpened("Выполнен корректный переход в браузер или на установку рекламируемого приложения")
     }
 
     private companion object {

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/RewardedLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/RewardedLoadTest.kt
@@ -6,20 +6,17 @@ import com.yandex.ads.sample.HomeActivity
 import com.yandex.ads.sample.base.BaseUITest
 import com.yandex.ads.sample.base.defaultExt
 import com.yandex.ads.sample.pageobjects.RewardedScreen
-import com.yandex.ads.sample.pageobjects.clickCallToAction
-import com.yandex.ads.sample.pageobjects.clickShowAd
 import com.yandex.ads.sample.shared_steps.GoToSection
 import com.yandex.ads.sample.shared_steps.checkAnyBrowserOrStoreIsOpened
+import com.yandex.ads.sample.shared_steps.clickCallToAction
+import com.yandex.ads.sample.shared_steps.clickShowAd
 import com.yandex.ads.sample.shared_steps.choiceNetwork
 import com.yandex.ads.sample.shared_steps.goToSection
 import com.yandex.ads.sample.shared_steps.openSampleApp
 import com.yandex.mobile.ads.common.AdActivity
-import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
-@Ignore("Bad test stability")
 internal class RewardedLoadTest : BaseUITest() {
     @get:Rule
     val activityRule = activityScenarioRule<HomeActivity>()
@@ -45,25 +42,17 @@ internal class RewardedLoadTest : BaseUITest() {
             }
         }
 
-        step("Нажать на кнопку \"Show ad\"") {
-            onScreen<RewardedScreen> {
-                flakySafely {
-                    clickShowAd()
-                }
-            }
+        clickShowAd()
 
-            step("Успешно отобразилась реклама") {
-                flakySafely(60_000) {
-                    device.activities.isCurrent(AdActivity::class.java)
-                }
+        step("Успешно отобразилась реклама") {
+            flakySafely(60_000) {
+                device.activities.isCurrent(AdActivity::class.java)
             }
         }
 
-        step("Кликнуть по рекламе") {
-            onScreen<RewardedScreen> { clickCallToAction() }
+        clickCallToAction()
 
-            checkAnyBrowserOrStoreIsOpened("Выполнен корректный переход в браузер или на установку рекламируемого приложения")
-        }
+        checkAnyBrowserOrStoreIsOpened("Выполнен корректный переход в браузер или на установку рекламируемого приложения")
     }
 
     private companion object {

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/adfox/AdfoxCarouselCallbacksTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/adfox/AdfoxCarouselCallbacksTest.kt
@@ -67,15 +67,10 @@ internal class AdfoxCarouselCallbacksTest : BaseUITest() {
                     "Ads loaded",
                     "Impression: null",
                     "Ad clicked",
-                    "Left application",
-                    "Returned to application",
                     "Impression: null",
                     "Ad clicked",
-                    "Left application",
-                    "Returned to application"
                 )
             }
         }
     }
 }
-

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/compose/ComposeAppOpenAdLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/compose/ComposeAppOpenAdLoadTest.kt
@@ -1,0 +1,64 @@
+package com.yandex.ads.sample.tests.compose
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.yandex.ads.sample.base.BaseUITest
+import com.yandex.ads.sample.compose.ComposeExamplesActivity
+import com.yandex.ads.sample.shared_steps.checkAnyBrowserOrStoreIsOpened
+import com.yandex.ads.sample.shared_steps.clickCallToAction
+import com.yandex.mobile.ads.common.AdActivity
+import org.junit.Rule
+import org.junit.Test
+
+internal class ComposeAppOpenAdLoadTest : BaseUITest() {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComposeExamplesActivity>()
+
+    @Test
+    fun shouldLoadComposeAppOpenAdAndNavigateToBrowser() = run {
+        step("Перейти на экран Compose App Open Ad") {
+            composeTestRule.onNodeWithText("AppOpenAd").performClick()
+        }
+
+        step("Нажать на кнопку \"Load\"") {
+            composeTestRule.onNodeWithText("Load").performClick()
+        }
+
+        step("Подождать результат загрузки рекламы") {
+            composeTestRule.waitUntil(timeoutMillis = 60_000) {
+                composeTestRule
+                    .onAllNodesWithText("onAdLoaded", substring = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty() ||
+                composeTestRule
+                    .onAllNodesWithText(NO_ADS_AVAILABLE_MESSAGE, substring = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+        }
+
+        step("Нажать на кнопку \"Show\"") {
+            flakySafely {
+                composeTestRule.onNodeWithText("Show").performClick()
+            }
+
+            step("Успешно отобразилась реклама") {
+                flakySafely(30_000) {
+                    device.activities.isCurrent(AdActivity::class.java)
+                }
+            }
+        }
+
+        clickCallToAction()
+
+        checkAnyBrowserOrStoreIsOpened("Выполнен корректный переход в браузер или на установку рекламируемого приложения")
+    }
+
+    private companion object {
+        private const val NO_ADS_AVAILABLE_MESSAGE =
+            "Ad request completed successfully, but there are no ads available."
+    }
+}

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/compose/ComposeInlineBannerLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/compose/ComposeInlineBannerLoadTest.kt
@@ -1,0 +1,44 @@
+package com.yandex.ads.sample.tests.compose
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.yandex.ads.sample.base.BaseUITest
+import com.yandex.ads.sample.compose.ComposeExamplesActivity
+import com.yandex.ads.sample.shared_steps.checkAnyBrowserOrStoreIsOpened
+import org.junit.Rule
+import org.junit.Test
+
+internal class ComposeInlineBannerLoadTest : BaseUITest() {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComposeExamplesActivity>()
+
+    @Test
+    fun shouldLoadComposeInlineBannerAndNavigateToBrowser() = run {
+        step("Перейти на экран Compose Inline Banner") {
+            composeTestRule.onNodeWithText("Inline banner").performClick()
+        }
+
+        step("Дождаться загрузки баннера") {
+            composeTestRule.waitUntil(timeoutMillis = 30_000) {
+                composeTestRule
+                    .onAllNodesWithText("onAdLoaded", substring = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+        }
+
+        step("Кликнуть по рекламе") {
+            composeTestRule.onNodeWithTag(BANNER_TAG).performClick()
+
+            checkAnyBrowserOrStoreIsOpened("Выполнен корректный переход в браузер или на установку рекламируемого приложения")
+        }
+    }
+
+    private companion object {
+        private const val BANNER_TAG = "banner"
+    }
+}

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/compose/ComposeInterstitialLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/compose/ComposeInterstitialLoadTest.kt
@@ -1,0 +1,64 @@
+package com.yandex.ads.sample.tests.compose
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.yandex.ads.sample.base.BaseUITest
+import com.yandex.ads.sample.compose.ComposeExamplesActivity
+import com.yandex.ads.sample.shared_steps.checkAnyBrowserOrStoreIsOpened
+import com.yandex.ads.sample.shared_steps.clickCallToAction
+import com.yandex.mobile.ads.common.AdActivity
+import org.junit.Rule
+import org.junit.Test
+
+internal class ComposeInterstitialLoadTest : BaseUITest() {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComposeExamplesActivity>()
+
+    @Test
+    fun shouldLoadComposeInterstitialAdAndNavigateToBrowser() = run {
+        step("Перейти на экран Compose Interstitial") {
+            composeTestRule.onNodeWithText("Interstitial").performClick()
+        }
+
+        step("Нажать на кнопку \"Load\"") {
+            composeTestRule.onNodeWithText("Load").performClick()
+        }
+
+        step("Подождать результат загрузки рекламы") {
+            composeTestRule.waitUntil(timeoutMillis = 60_000) {
+                composeTestRule
+                    .onAllNodesWithText("onAdLoaded", substring = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty() ||
+                composeTestRule
+                    .onAllNodesWithText(NO_ADS_AVAILABLE_MESSAGE, substring = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+        }
+
+        step("Нажать на кнопку \"Show\"") {
+            flakySafely {
+                composeTestRule.onNodeWithText("Show").performClick()
+            }
+
+            step("Успешно отобразилась реклама") {
+                flakySafely(30_000) {
+                    device.activities.isCurrent(AdActivity::class.java)
+                }
+            }
+        }
+
+        clickCallToAction()
+
+        checkAnyBrowserOrStoreIsOpened("Выполнен корректный переход в браузер или на установку рекламируемого приложения")
+    }
+
+    private companion object {
+        private const val NO_ADS_AVAILABLE_MESSAGE =
+            "Ad request completed successfully, but there are no ads available."
+    }
+}

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/compose/ComposeRewardedLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/compose/ComposeRewardedLoadTest.kt
@@ -1,0 +1,64 @@
+package com.yandex.ads.sample.tests.compose
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.yandex.ads.sample.base.BaseUITest
+import com.yandex.ads.sample.compose.ComposeExamplesActivity
+import com.yandex.ads.sample.shared_steps.checkAnyBrowserOrStoreIsOpened
+import com.yandex.ads.sample.shared_steps.clickCallToAction
+import com.yandex.mobile.ads.common.AdActivity
+import org.junit.Rule
+import org.junit.Test
+
+internal class ComposeRewardedLoadTest : BaseUITest() {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComposeExamplesActivity>()
+
+    @Test
+    fun shouldLoadComposeRewardedAdAndNavigateToBrowser() = run {
+        step("Перейти на экран Compose Rewarded") {
+            composeTestRule.onNodeWithText("Rewarded").performClick()
+        }
+
+        step("Нажать на кнопку \"Load\"") {
+            composeTestRule.onNodeWithText("Load").performClick()
+        }
+
+        step("Подождать результат загрузки рекламы") {
+            composeTestRule.waitUntil(timeoutMillis = 60_000) {
+                composeTestRule
+                    .onAllNodesWithText("onAdLoaded", substring = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty() ||
+                composeTestRule
+                    .onAllNodesWithText(NO_ADS_AVAILABLE_MESSAGE, substring = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+        }
+
+        step("Нажать на кнопку \"Show\"") {
+            flakySafely {
+                composeTestRule.onNodeWithText("Show").performClick()
+            }
+
+            step("Успешно отобразилась реклама") {
+                flakySafely(60_000) {
+                    device.activities.isCurrent(AdActivity::class.java)
+                }
+            }
+        }
+
+        clickCallToAction()
+
+        checkAnyBrowserOrStoreIsOpened("Выполнен корректный переход в браузер или на установку рекламируемого приложения")
+    }
+
+    private companion object {
+        private const val NO_ADS_AVAILABLE_MESSAGE =
+            "Ad request completed successfully, but there are no ads available."
+    }
+}

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/compose/ComposeStickyBannerLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/compose/ComposeStickyBannerLoadTest.kt
@@ -1,0 +1,44 @@
+package com.yandex.ads.sample.tests.compose
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.yandex.ads.sample.base.BaseUITest
+import com.yandex.ads.sample.compose.ComposeExamplesActivity
+import com.yandex.ads.sample.shared_steps.checkAnyBrowserOrStoreIsOpened
+import org.junit.Rule
+import org.junit.Test
+
+internal class ComposeStickyBannerLoadTest : BaseUITest() {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComposeExamplesActivity>()
+
+    @Test
+    fun shouldLoadComposeStickyBannerAndNavigateToBrowser() = run {
+        step("Перейти на экран Compose Sticky Banner") {
+            composeTestRule.onNodeWithText("Sticky banner").performClick()
+        }
+
+        step("Дождаться загрузки баннера") {
+            composeTestRule.waitUntil(timeoutMillis = 30_000) {
+                composeTestRule
+                    .onAllNodesWithText("onAdLoaded", substring = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+        }
+
+        step("Кликнуть по рекламе") {
+            composeTestRule.onNodeWithTag(BANNER_TAG).performClick()
+
+            checkAnyBrowserOrStoreIsOpened("Выполнен корректный переход в браузер или на установку рекламируемого приложения")
+        }
+    }
+
+    private companion object {
+        private const val BANNER_TAG = "banner"
+    }
+}

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/mediation/InterstitialLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/mediation/InterstitialLoadTest.kt
@@ -8,12 +8,11 @@ import com.yandex.ads.sample.base.currentIsExternal
 import com.yandex.ads.sample.base.defaultExt
 import com.yandex.ads.sample.pageobjects.InterstitialScreen
 import com.yandex.ads.sample.pageobjects.SomeKindOfAppScreen
-import com.yandex.ads.sample.pageobjects.clickShowAd
 import com.yandex.ads.sample.shared_steps.GoToSection
 import com.yandex.ads.sample.shared_steps.choiceNetwork
+import com.yandex.ads.sample.shared_steps.clickShowAd
 import com.yandex.ads.sample.shared_steps.goToSection
 import com.yandex.ads.sample.shared_steps.openSampleApp
-import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -47,27 +46,21 @@ internal class InterstitialLoadTest(
             }
         }
 
-        step("Нажать на кнопку \"Show ad\"") {
-            onScreen<InterstitialScreen> {
-                flakySafely {
-                    clickShowAd()
+        clickShowAd()
+
+        step("Реклама загрузилась. В случае подбора рекламы отобразилась на полный экран.") {
+            val adScreen = SomeKindOfAppScreen()
+            compose(
+                timeoutMs = 30_000,
+                allowedExceptions = FlakySafetyParams.defaultExt
+            ) {
+                or(adScreen.rootView) {
+                    isDisplayed()
+                    device.activities.currentIsExternal()
                 }
-            }
 
-            step("Реклама загрузилась. В случае подбора рекламы отобразилась на полный экран.") {
-                val adScreen = SomeKindOfAppScreen()
-                compose(
-                    timeoutMs = 30_000,
-                    allowedExceptions = FlakySafetyParams.defaultExt
-                ) {
-                    or(adScreen.rootView) {
-                        isDisplayed()
-                        device.activities.currentIsExternal()
-                    }
-
-                    or(interstitialScreen.logsView) {
-                        containsMessage(NO_ADS_AVAILABLE_MESSAGE)
-                    }
+                or(interstitialScreen.logsView) {
+                    containsMessage(NO_ADS_AVAILABLE_MESSAGE)
                 }
             }
         }

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/mediation/NativeTemplateLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/mediation/NativeTemplateLoadTest.kt
@@ -16,7 +16,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
-@Ignore()
 @RunWith(Parameterized::class)
 internal class NativeTemplateLoadTest(
     private val networkItem: Class<out NativeTemplateScreen.NetworkItem>
@@ -43,9 +42,9 @@ internal class NativeTemplateLoadTest(
         step("Реклама загрузилась. В случае подбора рекламы она отображется") {
             onScreen<NativeTemplateScreen> {
                 compose(timeoutMs = 60_000) {
-//                    or(adView) {
-//                        isCompletelyDisplayed()
-//                    }
+                    or(adView) {
+                        isCompletelyDisplayed()
+                    }
 
                     or(logsView) {
                         hasSize(1)

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/mediation/NativeTemplateLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/mediation/NativeTemplateLoadTest.kt
@@ -10,11 +10,13 @@ import com.yandex.ads.sample.shared_steps.choiceNetwork
 import com.yandex.ads.sample.shared_steps.goToSection
 import com.yandex.ads.sample.shared_steps.openSampleApp
 import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
+@Ignore()
 @RunWith(Parameterized::class)
 internal class NativeTemplateLoadTest(
     private val networkItem: Class<out NativeTemplateScreen.NetworkItem>
@@ -41,9 +43,9 @@ internal class NativeTemplateLoadTest(
         step("Реклама загрузилась. В случае подбора рекламы она отображется") {
             onScreen<NativeTemplateScreen> {
                 compose(timeoutMs = 60_000) {
-                    or(adView) {
-                        isCompletelyDisplayed()
-                    }
+//                    or(adView) {
+//                        isCompletelyDisplayed()
+//                    }
 
                     or(logsView) {
                         hasSize(1)

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/mediation/RewardedLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/mediation/RewardedLoadTest.kt
@@ -8,12 +8,11 @@ import com.yandex.ads.sample.base.currentIsExternal
 import com.yandex.ads.sample.base.defaultExt
 import com.yandex.ads.sample.pageobjects.RewardedScreen
 import com.yandex.ads.sample.pageobjects.SomeKindOfAppScreen
-import com.yandex.ads.sample.pageobjects.clickShowAd
 import com.yandex.ads.sample.shared_steps.GoToSection
 import com.yandex.ads.sample.shared_steps.choiceNetwork
+import com.yandex.ads.sample.shared_steps.clickShowAd
 import com.yandex.ads.sample.shared_steps.goToSection
 import com.yandex.ads.sample.shared_steps.openSampleApp
-import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -47,23 +46,17 @@ internal class RewardedLoadTest(
             }
         }
 
-        step("Нажать на кнопку \"Show ad\"") {
-            onScreen<RewardedScreen> {
-                flakySafely {
-                    clickShowAd()
+        clickShowAd()
+
+        step("Реклама загрузилась. В случае подбора рекламы отобразилась на полный экран.") {
+            val adScreen = SomeKindOfAppScreen()
+            compose(timeoutMs = 60_000, allowedExceptions = FlakySafetyParams.defaultExt) {
+                or(rewardedScreen.logsView) {
+                    containsMessage(NO_ADS_AVAILABLE_MESSAGE)
                 }
-            }
 
-            step("Реклама загрузилась. В случае подбора рекламы отобразилась на полный экран.") {
-                val adScreen = SomeKindOfAppScreen()
-                compose(timeoutMs = 60_000, allowedExceptions = FlakySafetyParams.defaultExt) {
-                    or(rewardedScreen.logsView) {
-                        containsMessage(NO_ADS_AVAILABLE_MESSAGE)
-                    }
-
-                    or(adScreen.rootView) {
-                        device.activities.currentIsExternal()
-                    }
+                or(adScreen.rootView) {
+                    device.activities.currentIsExternal()
                 }
             }
         }

--- a/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/mediation/StickyBannerLoadTest.kt
+++ b/YandexMobileAdsExample/app/src/androidTest/java/com/yandex/ads/sample/tests/mediation/StickyBannerLoadTest.kt
@@ -10,13 +10,11 @@ import com.yandex.ads.sample.shared_steps.choiceNetwork
 import com.yandex.ads.sample.shared_steps.goToSection
 import com.yandex.ads.sample.shared_steps.openSampleApp
 import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
-@Ignore
 @RunWith(Parameterized::class)
 internal class StickyBannerLoadTest(
     private val networkItem: Class<out StickyBannerScreen.NetworkItem>

--- a/YandexMobileAdsExample/app/src/main/AndroidManifest.xml
+++ b/YandexMobileAdsExample/app/src/main/AndroidManifest.xml
@@ -63,6 +63,10 @@
             android:name=".HomeActivity"
             android:exported="false" />
         <activity
+            android:name=".compose.ComposeExamplesActivity"
+            android:exported="false"
+            android:label="Compose Examples" />
+        <activity
             android:name=".tv.TVActivity"
             android:exported="false" />
         <activity

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/Application.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/Application.kt
@@ -17,8 +17,8 @@ import com.yandex.ads.sample.settings.CoppaDialogFragment
 import com.yandex.ads.sample.settings.GdprDialogFragment
 import com.yandex.ads.sample.settings.LocationDialogFragment
 import com.yandex.ads.sample.utils.Logger
-import com.yandex.mobile.ads.common.MobileAds
-import com.yandex.mobile.ads.instream.MobileInstreamAds
+import com.yandex.mobile.ads.common.YandexAds
+import com.yandex.mobile.ads.instream.YandexInstreamAds
 
 class Application : MultiDexApplication() {
 
@@ -33,21 +33,21 @@ class Application : MultiDexApplication() {
     }
 
     private fun initSdk() {
-        MobileInstreamAds.setAdGroupPreloading(INSTREAM_AD_GROUP_PRELOADING_ENABLED)
-        MobileAds.initialize(this) {
+        YandexInstreamAds.setAdGroupPreloading(INSTREAM_AD_GROUP_PRELOADING_ENABLED)
+        YandexAds.initialize(this) {
             Logger.debug("SDK initialized")
             // wait until sdk initialized before using Ads
             initAppOpenAdManager()
         }
-        MobileAds.enableLogging(true)
+        YandexAds.enableLogging(true)
     }
 
     private fun initPreferences() {
         val preferences = PreferenceManager.getDefaultSharedPreferences(this)
         preferences.run {
-            MobileAds.setUserConsent(getBoolean(GdprDialogFragment.TAG, false))
-            MobileAds.setLocationConsent(getBoolean(LocationDialogFragment.TAG, false))
-            MobileAds.setAgeRestrictedUser(getBoolean(CoppaDialogFragment.TAG, false))
+            YandexAds.setUserConsent(getBoolean(GdprDialogFragment.TAG, false))
+            YandexAds.setLocationTracking(getBoolean(LocationDialogFragment.TAG, false))
+            YandexAds.setAgeRestricted(getBoolean(CoppaDialogFragment.TAG, false))
         }
     }
 

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/HomeActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/HomeActivity.kt
@@ -28,6 +28,7 @@ import com.yandex.ads.sample.adunits.NativeTemplateAdActivity
 import com.yandex.ads.sample.adunits.RewardedAdActivity
 import com.yandex.ads.sample.adunits.SimpleInstreamAdActivity
 import com.yandex.ads.sample.adunits.StickyBannerAdActivity
+import com.yandex.ads.sample.compose.ComposeExamplesActivity
 import com.yandex.ads.sample.databinding.ActivityHomeBinding
 import com.yandex.ads.sample.navigation.NavigationAdapter
 import com.yandex.ads.sample.navigation.NavigationItem
@@ -72,6 +73,11 @@ class HomeActivity : AppCompatActivity(R.layout.activity_home) {
         private const val NETWORK_WARNING = "networkWarning"
 
         private val adTypeItems = listOf(
+            NavigationItem(
+                R.drawable.ic_outline_developer_board_24,
+                R.string.compose_examples_title,
+                ActivityNavigation(ComposeExamplesActivity::class.java),
+            ),
             NavigationItem(
                 R.drawable.ic_outline_ad_units_24,
                 R.string.sticky_banner_title,

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adfoxcarousel/AdfoxCarouselAdapter.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adfoxcarousel/AdfoxCarouselAdapter.kt
@@ -9,13 +9,11 @@
 
 package com.yandex.ads.sample.adfoxcarousel
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.yandex.ads.sample.databinding.AdfoxCarouselItemBinding
 import com.yandex.mobile.ads.nativeads.NativeAd
-import com.yandex.mobile.ads.nativeads.NativeAdException
 import com.yandex.mobile.ads.nativeads.NativeAdViewBinder
 
 class AdfoxCarouselAdapter : RecyclerView.Adapter<NativeAdViewBinderHolder>() {
@@ -44,15 +42,6 @@ class AdfoxCarouselAdapter : RecyclerView.Adapter<NativeAdViewBinderHolder>() {
     }
 
     private fun bindNativeAd(nativeAd: NativeAd, viewBinder: NativeAdViewBinder) {
-        try {
-            nativeAd.bindNativeAd(viewBinder)
-        } catch (exception: NativeAdException) {
-            Log.d(VIEW_PAGER_TAG, "${exception.message}")
-        }
-    }
-
-    companion object {
-
-        private const val VIEW_PAGER_TAG = "ViewPagerAdapter"
+        nativeAd.bindNativeAd(viewBinder)
     }
 }

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/AdfoxCarouselAdActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/AdfoxCarouselAdActivity.kt
@@ -25,9 +25,10 @@ import com.yandex.ads.sample.network.Network
 import com.yandex.ads.sample.utils.applySystemBarsPadding
 import com.yandex.mobile.ads.common.AdRequestError
 import com.yandex.mobile.ads.common.ImpressionData
+import com.yandex.mobile.ads.common.AdRequest
 import com.yandex.mobile.ads.nativeads.NativeAd
 import com.yandex.mobile.ads.nativeads.NativeAdEventListener
-import com.yandex.mobile.ads.nativeads.NativeAdRequestConfiguration
+import com.yandex.mobile.ads.nativeads.NativeAdOptions
 import com.yandex.mobile.ads.nativeads.NativeAdViewBinder
 import com.yandex.mobile.ads.nativeads.SliderAd
 import com.yandex.mobile.ads.nativeads.SliderAdLoadListener
@@ -82,12 +83,18 @@ class AdfoxCarouselAdActivity : AppCompatActivity(R.layout.activity_adfox_carous
     }
 
     private fun loadAds() {
-        sliderAdLoader?.loadSlider(buildAdRequestConfiguration())
+        val adUnitId = adInfoFragment.selectedNetwork.adUnitId
+        val adRequest = AdRequest.Builder(adUnitId)
+            .setParameters(adFoxParameters)
+            .build()
+        val options = NativeAdOptions.Builder()
+            .setShouldLoadImagesAutomatically(true)
+            .build()
+        sliderAdLoader?.loadAd(adRequest, options, eventLogger)
     }
 
     private fun configureAdLoader() {
         sliderAdLoader = SliderAdLoader(this)
-        sliderAdLoader?.setSliderAdLoadListener(eventLogger)
     }
 
     private fun configureViewPager() {
@@ -97,14 +104,6 @@ class AdfoxCarouselAdActivity : AppCompatActivity(R.layout.activity_adfox_carous
         configureViewPagerControls()
     }
 
-    private fun buildAdRequestConfiguration(): NativeAdRequestConfiguration {
-        val adUnitId = adInfoFragment.selectedNetwork.adUnitId
-        return NativeAdRequestConfiguration
-            .Builder(adUnitId)
-            .setShouldLoadImagesAutomatically(true)
-            .setParameters(adFoxParameters)
-            .build()
-    }
 
     private fun bindSliderAd(sliderAd: SliderAd) {
         val viewBinder = NativeAdViewBinder.Builder(nativeAdView).build()
@@ -164,14 +163,6 @@ class AdfoxCarouselAdActivity : AppCompatActivity(R.layout.activity_adfox_carous
 
         override fun onAdClicked() {
             adInfoFragment.log("Ad clicked")
-        }
-
-        override fun onLeftApplication() {
-            adInfoFragment.log("Left application")
-        }
-
-        override fun onReturnedToApplication() {
-            adInfoFragment.log("Returned to application")
         }
 
         override fun onImpression(data: ImpressionData?) {

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/AppOpenAdActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/AppOpenAdActivity.kt
@@ -18,7 +18,7 @@ import com.yandex.ads.sample.network.Network
 import com.yandex.ads.sample.network.NetworkAdapter
 import com.yandex.ads.sample.utils.applySystemBarsPadding
 import com.yandex.mobile.ads.common.AdError
-import com.yandex.mobile.ads.common.AdRequestConfiguration
+import com.yandex.mobile.ads.common.AdRequest
 import com.yandex.mobile.ads.common.AdRequestError
 import com.yandex.mobile.ads.common.ImpressionData
 import com.yandex.mobile.ads.appopenad.AppOpenAd
@@ -47,10 +47,7 @@ class AppOpenAdActivity : AppCompatActivity(R.layout.activity_app_open_ad),
         binding.toolbar.setNavigationOnClickListener { onBackPressedDispatcher.onBackPressed() }
         binding.setupUi()
 
-        appOpenAdLoader = AppOpenAdLoader(this).apply {
-            setAdLoadListener(this@AppOpenAdActivity)
-        }
-
+        appOpenAdLoader = AppOpenAdLoader(this)
         loadAppOpenAd()
     }
 
@@ -68,11 +65,8 @@ class AppOpenAdActivity : AppCompatActivity(R.layout.activity_app_open_ad),
 
     private fun loadAppOpenAd() {
         disableShowAdButton()
-        appOpenAdLoader?.loadAd(createAdRequestConfiguration())
-    }
-
-    private fun createAdRequestConfiguration(): AdRequestConfiguration {
-        return AdRequestConfiguration.Builder(selectedNetwork.adUnitId).build()
+        val adRequest = AdRequest.Builder(selectedNetwork.adUnitId).build()
+        appOpenAdLoader?.loadAd(adRequest, this)
     }
 
     private fun showAppOpenAd() {
@@ -101,7 +95,7 @@ class AppOpenAdActivity : AppCompatActivity(R.layout.activity_app_open_ad),
     }
 
     override fun onDestroy() {
-        appOpenAdLoader?.setAdLoadListener(null)
+        appOpenAdLoader?.cancelLoading()
         appOpenAdLoader = null
         destroyAppOpen()
         super.onDestroy()

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/CustomNativeAdActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/CustomNativeAdActivity.kt
@@ -23,16 +23,16 @@ import androidx.fragment.app.commit
 import com.yandex.ads.sample.R
 import com.yandex.ads.sample.databinding.ActivityCustomNativeAdBinding
 import com.yandex.ads.sample.network.Network
-import com.yandex.ads.sample.utils.Logger
 import com.yandex.ads.sample.utils.applySystemBarsPadding
+import com.yandex.mobile.ads.common.AdBindingResult
 import com.yandex.mobile.ads.common.AdRequestError
 import com.yandex.mobile.ads.common.ImpressionData
+import com.yandex.mobile.ads.common.AdRequest
 import com.yandex.mobile.ads.nativeads.NativeAd
 import com.yandex.mobile.ads.nativeads.NativeAdEventListener
-import com.yandex.mobile.ads.nativeads.NativeAdException
 import com.yandex.mobile.ads.nativeads.NativeAdLoadListener
 import com.yandex.mobile.ads.nativeads.NativeAdLoader
-import com.yandex.mobile.ads.nativeads.NativeAdRequestConfiguration
+import com.yandex.mobile.ads.nativeads.NativeAdOptions
 import com.yandex.mobile.ads.nativeads.NativeAdViewBinder
 import org.json.JSONException
 import org.json.JSONObject
@@ -66,22 +66,33 @@ class CustomNativeAdActivity : AppCompatActivity(R.layout.activity_custom_native
     }
 
     private fun loadNative() {
-        createNative()
+        nativeAdLoader?.cancelLoading()
+        nativeAdLoader = NativeAdLoader(this)
         additionalContainer.removeAllViews()
         nativeAdView.isVisible = false
-        nativeAdLoader?.loadAd(buildAdRequestConfiguration())
-    }
-
-    private fun createNative() {
-        nativeAdLoader = NativeAdLoader(this)
-        nativeAdLoader?.setNativeAdLoadListener(eventLogger)
-    }
-
-    private fun buildAdRequestConfiguration(): NativeAdRequestConfiguration {
         val adUnitId = adInfoFragment.selectedNetwork.adUnitId
-        return NativeAdRequestConfiguration
-            .Builder(adUnitId)
+        val adRequest = buildAdRequest(adUnitId)
+        val options = NativeAdOptions.Builder()
             .setShouldLoadImagesAutomatically(true)
+            .build()
+        nativeAdLoader?.loadAd(adRequest, options, object : NativeAdLoadListener {
+            override fun onAdLoaded(nativeAd: NativeAd) {
+                adInfoFragment.log("Native ad loaded")
+                adInfoFragment.hideLoading()
+                bindNative(nativeAd)
+            }
+
+            override fun onAdFailedToLoad(error: AdRequestError) {
+                adInfoFragment.log(
+                    "Native ad failed to load with code ${error.code}: ${error.description}"
+                )
+                adInfoFragment.hideLoading()
+            }
+        })
+    }
+
+    private fun buildAdRequest(adUnitId: String): AdRequest {
+        return AdRequest.Builder(adUnitId)
             .apply {
                 if (adUnitId == AD_FOX_AD_UNIT_ID) {
                     setParameters(adFoxParameters)
@@ -109,13 +120,16 @@ class CustomNativeAdActivity : AppCompatActivity(R.layout.activity_custom_native
                 .build()
         }
 
-        try {
-            nativeAd.bindNativeAd(nativeAdViewBinder)
-            nativeAd.info?.let { processAdditionalText(it) }
-            nativeAd.setNativeAdEventListener(eventLogger)
-            nativeAdView.isVisible = true
-        } catch (exception: NativeAdException) {
-            Logger.error(exception.message.orEmpty())
+        when (nativeAd.bindNativeAd(nativeAdViewBinder)) {
+            is AdBindingResult.Success -> {
+                nativeAd.adInfo.partnerText?.let { processAdditionalText(it) }
+                nativeAd.setNativeAdEventListener(eventLogger)
+                nativeAdView.isVisible = true
+            }
+
+            is AdBindingResult.Failure -> {
+                nativeAdView.isVisible = false
+            }
         }
     }
 
@@ -166,36 +180,16 @@ class CustomNativeAdActivity : AppCompatActivity(R.layout.activity_custom_native
     }
 
     override fun onDestroy() {
+        nativeAdLoader?.cancelLoading()
         nativeAdLoader = null
         _adInfoFragment = null
         super.onDestroy()
     }
 
-    private inner class NativeAdEventLogger : NativeAdLoadListener, NativeAdEventListener {
-
-        override fun onAdLoaded(ad: NativeAd) {
-            adInfoFragment.log("Native ad loaded")
-            adInfoFragment.hideLoading()
-            bindNative(ad)
-        }
-
-        override fun onAdFailedToLoad(error: AdRequestError) {
-            adInfoFragment.log(
-                "Native ad failed to load with code ${error.code}: ${error.description}"
-            )
-            adInfoFragment.hideLoading()
-        }
+    private inner class NativeAdEventLogger : NativeAdEventListener {
 
         override fun onAdClicked() {
             adInfoFragment.log("Native ad clicked")
-        }
-
-        override fun onLeftApplication() {
-            adInfoFragment.log("Left application")
-        }
-
-        override fun onReturnedToApplication() {
-            adInfoFragment.log("Returned to application")
         }
 
         override fun onImpression(data: ImpressionData?) {

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/FeedActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/FeedActivity.kt
@@ -23,6 +23,7 @@ import com.yandex.ads.sample.feed.LogsDialog
 import com.yandex.ads.sample.utils.Logger
 import com.yandex.ads.sample.utils.ScreenUtil.screenWidth
 import com.yandex.ads.sample.utils.applySystemBarsPadding
+import com.yandex.mobile.ads.common.AdRequest
 import com.yandex.mobile.ads.common.AdRequestError
 import com.yandex.mobile.ads.common.ImpressionData
 import com.yandex.mobile.ads.feed.FeedAd
@@ -30,7 +31,6 @@ import com.yandex.mobile.ads.feed.FeedAdAdapter
 import com.yandex.mobile.ads.feed.FeedAdAppearance
 import com.yandex.mobile.ads.feed.FeedAdEventListener
 import com.yandex.mobile.ads.feed.FeedAdLoadListener
-import com.yandex.mobile.ads.feed.FeedAdRequestConfiguration
 import java.lang.StringBuilder
 
 class FeedActivity: AppCompatActivity() {
@@ -74,9 +74,9 @@ class FeedActivity: AppCompatActivity() {
             cardWidth = calculatedFeedCardWidth,
             cardCornerRadius = CARD_CORNER_RADIUS_DP
         )
-        val feedAdRequestConfiguration = FeedAdRequestConfiguration.Builder(AD_UNIT_ID).build()
+        val feedAdRequest = AdRequest.Builder(AD_UNIT_ID).build()
 
-        feedAd = FeedAd.Builder(this, feedAdRequestConfiguration, feedAdAppearance).build()
+        feedAd = FeedAd.Builder(this, feedAdRequest, feedAdAppearance).build()
         feedAd.loadListener = loadLogger
         feedAd.preloadAd()
     }

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/InlineBannerAdActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/InlineBannerAdActivity.kt
@@ -67,7 +67,7 @@ class InlineBannerAdActivity : AppCompatActivity(R.layout.activity_inline_banner
                 val adWidthPixels = binding.coordinatorLayout.width
                 val adWidth = (adWidthPixels / resources.displayMetrics.density).roundToInt()
                 val maxAdHeight = screenHeight / 3
-                bannerAdSize = BannerAdSize.inlineSize(this@InlineBannerAdActivity, adWidth, maxAdHeight)
+                bannerAdSize = BannerAdSize.inline(this@InlineBannerAdActivity, adWidth, maxAdHeight)
             }
         })
     }
@@ -77,20 +77,19 @@ class InlineBannerAdActivity : AppCompatActivity(R.layout.activity_inline_banner
             val selectedAdUnitId = adInfoFragment.selectedNetwork.adUnitId
             if (currentAdUnitId != selectedAdUnitId) {
                 destroyBanner()
-                createBanner(selectedAdUnitId, bannerAdSize)
+                createBanner(bannerAdSize)
+                currentAdUnitId = selectedAdUnitId
             }
-            val adRequest = AdRequest.Builder()
+            val adRequest = AdRequest.Builder(selectedAdUnitId)
                 .setParameters(getRequestParameters())
                 .build()
             bannerAd?.loadAd(adRequest)
         }
     }
 
-    private fun createBanner(adUnitId: String, bannerAdSize: BannerAdSize) {
+    private fun createBanner(bannerAdSize: BannerAdSize) {
         bannerAd = BannerAdView(this).apply {
             id = R.id.banner
-            setAdUnitId(adUnitId)
-            currentAdUnitId = adUnitId
             setAdSize(bannerAdSize)
             setBannerAdEventListener(eventLogger)
         }
@@ -144,14 +143,6 @@ class InlineBannerAdActivity : AppCompatActivity(R.layout.activity_inline_banner
 
         override fun onAdClicked() {
             _adInfoFragment?.log("Banner ad clicked")
-        }
-
-        override fun onLeftApplication() {
-            _adInfoFragment?.log("Left application")
-        }
-
-        override fun onReturnedToApplication() {
-            _adInfoFragment?.log("Returned to application")
         }
 
         override fun onImpression(data: ImpressionData?) {

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/InstreamAdBinderActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/InstreamAdBinderActivity.kt
@@ -20,11 +20,12 @@ import com.yandex.ads.sample.player.ad.SampleInstreamAdPlayer
 import com.yandex.ads.sample.player.content.ContentVideoPlayer
 import com.yandex.ads.sample.utils.applySystemBarsPadding
 import com.yandex.mobile.ads.instream.InstreamAd
-import com.yandex.mobile.ads.instream.InstreamAdBinder
+import com.yandex.mobile.ads.instream.binder.InstreamAdBinder
 import com.yandex.mobile.ads.instream.InstreamAdListener
 import com.yandex.mobile.ads.instream.InstreamAdLoadListener
 import com.yandex.mobile.ads.instream.InstreamAdLoader
-import com.yandex.mobile.ads.instream.InstreamAdRequestConfiguration
+import com.yandex.mobile.ads.instream.InstreamAdRequest
+import com.yandex.mobile.ads.instream.InstreamAdRequestError
 
 class InstreamAdBinderActivity : AppCompatActivity(R.layout.activity_instream_ad_binder) {
 
@@ -94,11 +95,10 @@ class InstreamAdBinderActivity : AppCompatActivity(R.layout.activity_instream_ad
 
     private fun loadInstreamAd() {
         instreamAdLoader = InstreamAdLoader(this)
-        instreamAdLoader?.setInstreamAdLoadListener(eventLogger)
 
         // Replace demo Page ID with actual Page ID
-        val configuration = InstreamAdRequestConfiguration.Builder(PAGE_ID).build()
-        instreamAdLoader?.loadInstreamAd(this, configuration)
+        val configuration = InstreamAdRequest.Builder(PAGE_ID).build()
+        instreamAdLoader?.loadAd(configuration, eventLogger)
     }
 
     private fun showInstreamAd(instreamAd: InstreamAd) {
@@ -122,8 +122,8 @@ class InstreamAdBinderActivity : AppCompatActivity(R.layout.activity_instream_ad
             showInstreamAd(ad)
         }
 
-        override fun onInstreamAdFailedToLoad(error: String) {
-            adInfoFragment.log("Instream ad failed to load: $error")
+        override fun onInstreamAdFailedToLoad(error: InstreamAdRequestError) {
+            adInfoFragment.log("Instream ad failed to load: ${error.description}")
         }
 
         override fun onInstreamAdCompleted() {

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/InstreamAdBinderActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/InstreamAdBinderActivity.kt
@@ -105,8 +105,8 @@ class InstreamAdBinderActivity : AppCompatActivity(R.layout.activity_instream_ad
         instreamAdBinder = InstreamAdBinder(
             this,
             instreamAd,
+            checkNotNull(contentVideoPlayer),
             checkNotNull(instreamAdPlayer),
-            checkNotNull(contentVideoPlayer)
         )
         instreamAdBinder?.apply {
             setInstreamAdListener(eventLogger)

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/InstreamAdInrollActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/InstreamAdInrollActivity.kt
@@ -23,12 +23,13 @@ import com.yandex.ads.sample.utils.Logger
 import com.yandex.ads.sample.utils.applySystemBarsPadding
 import com.yandex.mobile.ads.instream.InstreamAd
 import com.yandex.mobile.ads.instream.InstreamAdBreakEventListener
+import com.yandex.mobile.ads.instream.InstreamAdBreakType
 import com.yandex.mobile.ads.instream.InstreamAdListener
 import com.yandex.mobile.ads.instream.InstreamAdLoadListener
 import com.yandex.mobile.ads.instream.InstreamAdLoader
-import com.yandex.mobile.ads.instream.InstreamAdRequestConfiguration
-import com.yandex.mobile.ads.instream.inroll.Inroll
-import com.yandex.mobile.ads.instream.inroll.InrollQueueProvider
+import com.yandex.mobile.ads.instream.InstreamAdRequest
+import com.yandex.mobile.ads.instream.InstreamAdRequestError
+import com.yandex.mobile.ads.instream.adbreak.InstreamAdBreak
 
 class InstreamAdInrollActivity : AppCompatActivity(R.layout.activity_instream_ad_inroll) {
 
@@ -37,7 +38,7 @@ class InstreamAdInrollActivity : AppCompatActivity(R.layout.activity_instream_ad
 
     private var instreamAdPlayer: SampleInstreamAdPlayer? = null
     private var contentVideoPlayer: ContentVideoPlayer? = null
-    private var currentInroll: Inroll? = null
+    private var currentInroll: InstreamAdBreak? = null
     private var activePlayer: SamplePlayer? = null
     private var isAdPlaying = false
     private var _adInfoFragment: AdInfoFragment? = null
@@ -77,17 +78,17 @@ class InstreamAdInrollActivity : AppCompatActivity(R.layout.activity_instream_ad
 
     private fun loadInstreamAd() {
         val instreamAdLoader = InstreamAdLoader(this)
-        instreamAdLoader.setInstreamAdLoadListener(eventLogger)
 
         // Replace demo Page ID with actual Page ID
-        val configuration = InstreamAdRequestConfiguration.Builder(PAGE_ID).build()
-        instreamAdLoader.loadInstreamAd(this, configuration)
+        val configuration = InstreamAdRequest.Builder(PAGE_ID).build()
+        instreamAdLoader.loadAd(configuration, eventLogger)
     }
 
     private fun showInstreamAd(instreamAd: InstreamAd) {
-        val inrollQueueProvider = InrollQueueProvider(this, instreamAd)
-        val instreamAdBreakQueue = inrollQueueProvider.queue
-        currentInroll = instreamAdBreakQueue.poll()?.apply {
+        val inrolls = instreamAd.instreamAdBreaks
+            .filter { it.adBreakData.type == InstreamAdBreakType.INROLL }
+        val instreamAdBreakQueue = ArrayDeque(inrolls)
+        currentInroll = instreamAdBreakQueue.removeFirstOrNull()?.apply {
             setListener(InrollListener())
             instreamAdPlayer?.let(::prepare)
             binding.playButton.apply {
@@ -187,8 +188,8 @@ class InstreamAdInrollActivity : AppCompatActivity(R.layout.activity_instream_ad
             showInstreamAd(ad)
         }
 
-        override fun onInstreamAdFailedToLoad(error: String) {
-            adInfoFragment.log("Instream ad failed to load: $error")
+        override fun onInstreamAdFailedToLoad(error: InstreamAdRequestError) {
+            adInfoFragment.log("Instream ad failed to load: ${error.description}")
         }
 
         override fun onInstreamAdCompleted() {

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/InterstitialAdActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/InterstitialAdActivity.kt
@@ -18,7 +18,7 @@ import com.yandex.ads.sample.network.Network
 import com.yandex.ads.sample.network.NetworkAdapter
 import com.yandex.ads.sample.utils.applySystemBarsPadding
 import com.yandex.mobile.ads.common.AdError
-import com.yandex.mobile.ads.common.AdRequestConfiguration
+import com.yandex.mobile.ads.common.AdRequest
 import com.yandex.mobile.ads.common.AdRequestError
 import com.yandex.mobile.ads.common.ImpressionData
 import com.yandex.mobile.ads.interstitial.InterstitialAd
@@ -50,23 +50,22 @@ class InterstitialAdActivity : AppCompatActivity(R.layout.activity_interstitial_
         // Initialize SDK as early as possible, for example in Application.onCreate or at least Activity.onCreate
         // It's recommended to use the same instance of InterstitialAdLoader for every load for
         // achieve better performance
-        interstitialAdLoader = InterstitialAdLoader(this).apply {
-            setAdLoadListener(this@InterstitialAdActivity)
-        }
+        interstitialAdLoader = InterstitialAdLoader(this)
         loadInterstitialAd()
     }
 
     private fun loadInterstitialAd() {
         disableShowAdButton()
-        interstitialAdLoader?.loadAd(createAdRequestConfiguration())
+        val adRequest = createAdRequest()
+        interstitialAdLoader?.loadAd(adRequest, this)
     }
 
-    private fun createAdRequestConfiguration(): AdRequestConfiguration {
+    private fun createAdRequest(): AdRequest {
         return if (selectedNetwork.titleId == R.string.adfox_title) {
-            AdRequestConfiguration.Builder(selectedNetwork.adUnitId)
+            AdRequest.Builder(selectedNetwork.adUnitId, )
                 .setParameters(adFoxRequestParameters)
         } else {
-            AdRequestConfiguration.Builder(selectedNetwork.adUnitId)
+            AdRequest.Builder(selectedNetwork.adUnitId)
         }.build()
     }
 
@@ -99,8 +98,7 @@ class InterstitialAdActivity : AppCompatActivity(R.layout.activity_interstitial_
     }
 
     override fun onDestroy() {
-        // set listener to null to avoid memory leaks
-        interstitialAdLoader?.setAdLoadListener(null)
+        interstitialAdLoader?.cancelLoading()
         interstitialAdLoader = null
         destroyInterstitial()
         super.onDestroy()

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/NativeTemplateAdActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/NativeTemplateAdActivity.kt
@@ -12,19 +12,19 @@ package com.yandex.ads.sample.adunits
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.isVisible
 import androidx.fragment.app.commit
 import com.yandex.ads.sample.R
 import com.yandex.ads.sample.databinding.ActivityNativeTemplateAdBinding
 import com.yandex.ads.sample.network.Network
 import com.yandex.ads.sample.utils.applySystemBarsPadding
+import com.yandex.mobile.ads.common.AdRequest
 import com.yandex.mobile.ads.common.AdRequestError
 import com.yandex.mobile.ads.common.ImpressionData
 import com.yandex.mobile.ads.nativeads.NativeAd
 import com.yandex.mobile.ads.nativeads.NativeAdEventListener
 import com.yandex.mobile.ads.nativeads.NativeAdLoadListener
 import com.yandex.mobile.ads.nativeads.NativeAdLoader
-import com.yandex.mobile.ads.nativeads.NativeAdRequestConfiguration
+import com.yandex.mobile.ads.nativeads.NativeAdOptions
 
 class NativeTemplateAdActivity : AppCompatActivity(R.layout.activity_native_template_ad) {
 
@@ -53,58 +53,44 @@ class NativeTemplateAdActivity : AppCompatActivity(R.layout.activity_native_temp
     }
 
     private fun loadNative() {
-        createNative()
-        nativeAdLoader?.loadAd(
-            NativeAdRequestConfiguration
-                .Builder(adInfoFragment.selectedNetwork.adUnitId)
-                .setParameters(adFoxParameters)
-                .setShouldLoadImagesAutomatically(true)
-                .build()
-        )
-    }
-
-    private fun bindNative(nativeAd: NativeAd) {
-        nativeAd.setNativeAdEventListener(eventLogger)
-        binding.nativeBanner.isVisible = true
-        binding.nativeBanner.setAd(nativeAd)
-    }
-
-    private fun createNative() {
+        nativeAdLoader?.cancelLoading()
         nativeAdLoader = NativeAdLoader(this)
-        nativeAdLoader?.setNativeAdLoadListener(eventLogger)
+        val adUnitId = adInfoFragment.selectedNetwork.adUnitId
+        val options = NativeAdOptions.Builder()
+            .setShouldLoadImagesAutomatically(true)
+            .build()
+        val adRequest = AdRequest.Builder(adUnitId)
+            .setParameters(adFoxParameters)
+            .build()
+        nativeAdLoader?.loadAd(adRequest, options, object : NativeAdLoadListener {
+            override fun onAdLoaded(nativeAd: NativeAd) {
+                adInfoFragment.log("Native ad loaded")
+                adInfoFragment.hideLoading()
+                nativeAd.setNativeAdEventListener(eventLogger)
+//                binding.nativeBanner.isVisible = true
+//                binding.nativeBanner.setAd(nativeAd)
+            }
+
+            override fun onAdFailedToLoad(error: AdRequestError) {
+                adInfoFragment.log(
+                    "Native ad failed to load with code ${error.code}: ${error.description}"
+                )
+                adInfoFragment.hideLoading()
+            }
+        })
     }
 
     override fun onDestroy() {
+        nativeAdLoader?.cancelLoading()
         nativeAdLoader = null
         _adInfoFragment = null
         super.onDestroy()
     }
 
-    private inner class NativeAdEventLogger : NativeAdLoadListener, NativeAdEventListener {
-
-        override fun onAdLoaded(ad: NativeAd) {
-            adInfoFragment.log("Native ad loaded")
-            adInfoFragment.hideLoading()
-            bindNative(ad)
-        }
-
-        override fun onAdFailedToLoad(error: AdRequestError) {
-            adInfoFragment.log(
-                "Native ad failed to load with code ${error.code}: ${error.description}"
-            )
-            adInfoFragment.hideLoading()
-        }
+    private inner class NativeAdEventLogger : NativeAdEventListener {
 
         override fun onAdClicked() {
             adInfoFragment.log("Native ad clicked")
-        }
-
-        override fun onLeftApplication() {
-            adInfoFragment.log("Left application")
-        }
-
-        override fun onReturnedToApplication() {
-            adInfoFragment.log("Returned to application")
         }
 
         override fun onImpression(data: ImpressionData?) {
@@ -115,14 +101,30 @@ class NativeTemplateAdActivity : AppCompatActivity(R.layout.activity_native_temp
     companion object {
 
         private val networks = arrayListOf(
-            Network(R.drawable.ic_yandex_icon_24, R.string.yandex_title, "demo-native-content-yandex"),
-            Network(R.drawable.ic_admanager_icon, R.string.admanager_title, "demo-native-admanager"),
+            Network(
+                R.drawable.ic_yandex_icon_24,
+                R.string.yandex_title,
+                "demo-native-content-yandex"
+            ),
+            Network(
+                R.drawable.ic_admanager_icon,
+                R.string.admanager_title,
+                "demo-native-admanager"
+            ),
             Network(R.drawable.ic_admob_icon_24, R.string.admob_title, "demo-native-admob"),
             Network(R.drawable.ic_appnext_icon, R.string.appnext_title, "demo-native-appnext"),
             Network(R.drawable.ic_bigoads_icon, R.string.bigoads_title, "demo-native-bigoads"),
-            Network(R.drawable.ic_mytarget_icon_24, R.string.my_target_title, "demo-native-mytarget"),
+            Network(
+                R.drawable.ic_mytarget_icon_24,
+                R.string.my_target_title,
+                "demo-native-mytarget"
+            ),
             Network(R.drawable.ic_pangle_icon, R.string.pangle_title, "demo-native-pangle"),
-            Network(R.drawable.ic_startapp_icon_24, R.string.startapp_title, "demo-native-startapp"),
+            Network(
+                R.drawable.ic_startapp_icon_24,
+                R.string.startapp_title,
+                "demo-native-startapp"
+            ),
             Network(R.drawable.ic_adfox_icon, R.string.adfox_title, "R-M-243655-10"),
         )
 

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/NativeTemplateAdActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/NativeTemplateAdActivity.kt
@@ -55,6 +55,7 @@ class NativeTemplateAdActivity : AppCompatActivity(R.layout.activity_native_temp
     private fun loadNative() {
         nativeAdLoader?.cancelLoading()
         nativeAdLoader = NativeAdLoader(this)
+        binding.nativeBanner.release()
         val adUnitId = adInfoFragment.selectedNetwork.adUnitId
         val options = NativeAdOptions.Builder()
             .setShouldLoadImagesAutomatically(true)
@@ -67,8 +68,7 @@ class NativeTemplateAdActivity : AppCompatActivity(R.layout.activity_native_temp
                 adInfoFragment.log("Native ad loaded")
                 adInfoFragment.hideLoading()
                 nativeAd.setNativeAdEventListener(eventLogger)
-//                binding.nativeBanner.isVisible = true
-//                binding.nativeBanner.setAd(nativeAd)
+                binding.nativeBanner.bindNativeAd(nativeAd)
             }
 
             override fun onAdFailedToLoad(error: AdRequestError) {
@@ -84,6 +84,7 @@ class NativeTemplateAdActivity : AppCompatActivity(R.layout.activity_native_temp
         nativeAdLoader?.cancelLoading()
         nativeAdLoader = null
         _adInfoFragment = null
+        binding.nativeBanner.release()
         super.onDestroy()
     }
 

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/RewardedAdActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/RewardedAdActivity.kt
@@ -18,14 +18,14 @@ import com.yandex.ads.sample.network.Network
 import com.yandex.ads.sample.network.NetworkAdapter
 import com.yandex.ads.sample.utils.applySystemBarsPadding
 import com.yandex.mobile.ads.common.AdError
-import com.yandex.mobile.ads.common.AdRequestConfiguration
+import com.yandex.mobile.ads.common.AdRequest
 import com.yandex.mobile.ads.common.AdRequestError
 import com.yandex.mobile.ads.common.ImpressionData
 import com.yandex.mobile.ads.rewarded.Reward
 import com.yandex.mobile.ads.rewarded.RewardedAd
 import com.yandex.mobile.ads.rewarded.RewardedAdEventListener
-import com.yandex.mobile.ads.rewarded.RewardedAdLoader
 import com.yandex.mobile.ads.rewarded.RewardedAdLoadListener
+import com.yandex.mobile.ads.rewarded.RewardedAdLoader
 
 class RewardedAdActivity : AppCompatActivity(R.layout.activity_rewarded_ad),
     RewardedAdLoadListener {
@@ -51,19 +51,15 @@ class RewardedAdActivity : AppCompatActivity(R.layout.activity_rewarded_ad),
         // Initialize SDK as early as possible, for example in Application.onCreate or at least Activity.onCreate
         // It's recommended to use the same instance of InterstitialAdLoader for every load for
         // achieve better performance
-        rewardedAdLoader = RewardedAdLoader(this).apply {
-            setAdLoadListener(this@RewardedAdActivity)
-        }
+        rewardedAdLoader = RewardedAdLoader(this)
         loadRewardedAd()
     }
 
     private fun loadRewardedAd() {
         disabeShowAdButton()
-        rewardedAdLoader?.loadAd(createAdRequestConfiguration())
+        val adRequest = AdRequest.Builder(selectedNetwork.adUnitId).build()
+        rewardedAdLoader?.loadAd(adRequest, this)
     }
-
-    private fun createAdRequestConfiguration(): AdRequestConfiguration =
-        AdRequestConfiguration.Builder(selectedNetwork.adUnitId).build()
 
     private fun showRewardedAd() {
         disabeShowAdButton()
@@ -94,8 +90,7 @@ class RewardedAdActivity : AppCompatActivity(R.layout.activity_rewarded_ad),
     }
 
     override fun onDestroy() {
-        // Set listener to null to avoid memory leaks
-        rewardedAdLoader?.setAdLoadListener(null)
+        rewardedAdLoader?.cancelLoading()
         rewardedAdLoader = null
         destroyRewardedAd()
         super.onDestroy()
@@ -160,20 +155,52 @@ class RewardedAdActivity : AppCompatActivity(R.layout.activity_rewarded_ad),
 
         private val networks = arrayListOf(
             Network(R.drawable.ic_yandex_icon_24, R.string.yandex_title, "demo-rewarded-yandex"),
-            Network(R.drawable.ic_admanager_icon, R.string.admanager_title, "demo-rewarded-admanager"),
+            Network(
+                R.drawable.ic_admanager_icon,
+                R.string.admanager_title,
+                "demo-rewarded-admanager"
+            ),
             Network(R.drawable.ic_admob_icon_24, R.string.admob_title, "demo-rewarded-admob"),
-            Network(R.drawable.ic_applovin_icon_24, R.string.applovin_title, "demo-rewarded-applovin"),
+            Network(
+                R.drawable.ic_applovin_icon_24,
+                R.string.applovin_title,
+                "demo-rewarded-applovin"
+            ),
             Network(R.drawable.ic_appnext_icon, R.string.appnext_title, "demo-rewarded-appnext"),
             Network(R.drawable.ic_bigoads_icon, R.string.bigoads_title, "demo-rewarded-bigoads"),
-            Network(R.drawable.ic_chartboost_icon, R.string.chartboost_title, "demo-rewarded-chartboost"),
+            Network(
+                R.drawable.ic_chartboost_icon,
+                R.string.chartboost_title,
+                "demo-rewarded-chartboost"
+            ),
             Network(R.drawable.ic_inmobi_icon, R.string.inmobi_title, "demo-rewarded-inmobi"),
-            Network(R.drawable.ic_mintegral_logo, R.string.mintegral_title, "demo-rewarded-mintegral"),
-            Network(R.drawable.ic_mytarget_icon_24, R.string.my_target_title, "demo-rewarded-mytarget"),
-            Network(R.drawable.ic_ironsource_icon_24, R.string.ironsource_title, "demo-rewarded-ironsource"),
+            Network(
+                R.drawable.ic_mintegral_logo,
+                R.string.mintegral_title,
+                "demo-rewarded-mintegral"
+            ),
+            Network(
+                R.drawable.ic_mytarget_icon_24,
+                R.string.my_target_title,
+                "demo-rewarded-mytarget"
+            ),
+            Network(
+                R.drawable.ic_ironsource_icon_24,
+                R.string.ironsource_title,
+                "demo-rewarded-ironsource"
+            ),
             Network(R.drawable.ic_pangle_icon, R.string.pangle_title, "demo-rewarded-pangle"),
-            Network(R.drawable.ic_startapp_icon_24, R.string.startapp_title, "demo-rewarded-startapp"),
+            Network(
+                R.drawable.ic_startapp_icon_24,
+                R.string.startapp_title,
+                "demo-rewarded-startapp"
+            ),
             Network(R.drawable.ic_tapjoy_icon, R.string.tapjoy_title, "demo-rewarded-tapjoy"),
-            Network(R.drawable.ic_unityads_icon_24, R.string.unity_ads_title, "demo-rewarded-unityads"),
+            Network(
+                R.drawable.ic_unityads_icon_24,
+                R.string.unity_ads_title,
+                "demo-rewarded-unityads"
+            ),
             Network(R.drawable.ic_vungle_icon_24, R.string.vungle_title, "demo-rewarded-vungle"),
         )
     }

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/SimpleInstreamAdActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/SimpleInstreamAdActivity.kt
@@ -23,7 +23,7 @@ import com.yandex.ads.sample.R
 import com.yandex.ads.sample.databinding.ActivitySimpleInstreamAdBinding
 import com.yandex.ads.sample.network.Network
 import com.yandex.ads.sample.utils.applySystemBarsPadding
-import com.yandex.mobile.ads.instream.InstreamAdRequestConfiguration
+import com.yandex.mobile.ads.instream.InstreamAdRequest
 import com.yandex.mobile.ads.instream.media3.YandexAdsLoader
 
 class SimpleInstreamAdActivity : AppCompatActivity(R.layout.activity_simple_instream_ad) {
@@ -59,7 +59,7 @@ class SimpleInstreamAdActivity : AppCompatActivity(R.layout.activity_simple_inst
     }
 
     private fun initAdsLoader() {
-        val configuration = InstreamAdRequestConfiguration
+        val configuration = InstreamAdRequest
             .Builder(networks.first().adUnitId)
             .build()
         yandexAdsLoader = YandexAdsLoader(this, configuration)

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/StickyBannerAdActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/adunits/StickyBannerAdActivity.kt
@@ -65,11 +65,11 @@ class StickyBannerAdActivity : AppCompatActivity(R.layout.activity_sticky_banner
                 val adWidthPixels = binding.coordinatorLayout.width
                 val adWidthDp = (adWidthPixels / resources.displayMetrics.density).roundToInt()
 
-                // For achieve the best performance of sticky banner BannerAdSize.stickySize
+                // For achieve the best performance of sticky banner BannerAdSize.sticky
                 // should be called after SDK initialization.
                 // Initialize SDK as early as possible, for example in Application.onCreate
                 // or at least Activity.onCreate
-                bannerAdSize = BannerAdSize.stickySize(this@StickyBannerAdActivity, adWidthDp)
+                bannerAdSize = BannerAdSize.sticky(this@StickyBannerAdActivity, adWidthDp)
             }
         })
     }
@@ -79,9 +79,10 @@ class StickyBannerAdActivity : AppCompatActivity(R.layout.activity_sticky_banner
             val selectedAdUnitId = adInfoFragment.selectedNetwork.adUnitId
             if (currentAdUnitId != selectedAdUnitId) {
                 destroyBanner()
-                createBanner(selectedAdUnitId, bannerAdSize)
+                createBanner(bannerAdSize)
+                currentAdUnitId = selectedAdUnitId
             }
-            val adRequest = AdRequest.Builder()
+            val adRequest = AdRequest.Builder(selectedAdUnitId)
                 .setParameters(getRequestParameters())
                 .build()
             bannerAd?.loadAd(adRequest)
@@ -89,11 +90,9 @@ class StickyBannerAdActivity : AppCompatActivity(R.layout.activity_sticky_banner
         }
     }
 
-    private fun createBanner(adUnitId: String, bannerAdSize: BannerAdSize) {
+    private fun createBanner(bannerAdSize: BannerAdSize) {
         bannerAd = BannerAdView(this).apply {
             id = R.id.banner
-            setAdUnitId(adUnitId)
-            currentAdUnitId = adUnitId
             setAdSize(bannerAdSize)
             setBannerAdEventListener(eventLogger)
         }
@@ -144,14 +143,6 @@ class StickyBannerAdActivity : AppCompatActivity(R.layout.activity_sticky_banner
 
         override fun onAdClicked() {
             adInfoFragment.log("Banner ad clicked")
-        }
-
-        override fun onLeftApplication() {
-            adInfoFragment.log("Left application")
-        }
-
-        override fun onReturnedToApplication() {
-            adInfoFragment.log("Returned to application")
         }
 
         override fun onImpression(data: ImpressionData?) {

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/appopenad/AppOpenAdManager.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/appopenad/AppOpenAdManager.kt
@@ -11,13 +11,13 @@ import com.yandex.mobile.ads.appopenad.AppOpenAdEventListener
 import com.yandex.mobile.ads.appopenad.AppOpenAdLoadListener
 import com.yandex.mobile.ads.appopenad.AppOpenAdLoader
 import com.yandex.mobile.ads.common.AdError
-import com.yandex.mobile.ads.common.AdRequestConfiguration
+import com.yandex.mobile.ads.common.AdRequest
 import com.yandex.mobile.ads.common.AdRequestError
 import com.yandex.mobile.ads.common.ImpressionData
 import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicBoolean
 
-class AppOpenAdManager(application: Application) : AppOpenAdLoadListener {
+class AppOpenAdManager(application: Application): AppOpenAdLoadListener {
 
     private val context: Context = application
 
@@ -27,7 +27,8 @@ class AppOpenAdManager(application: Application) : AppOpenAdLoadListener {
     private val appOpenAdActivityObserver = AppOpenAdActivityObserver()
 
     private val appOpenAdLoader = AppOpenAdLoader(application)
-    private val adRequestConfiguration = AdRequestConfiguration.Builder(AD_UNIT_ID).build()
+    private val adRequest = AdRequest.Builder(AD_UNIT_ID).build()
+
     private var loadingInProgress = AtomicBoolean(false)
     private var activityReference: WeakReference<Activity>? = null
     private var appOpenAd: AppOpenAd? = null
@@ -42,7 +43,6 @@ class AppOpenAdManager(application: Application) : AppOpenAdLoadListener {
     }
 
     fun initialize() {
-        appOpenAdLoader.setAdLoadListener(this)
         // load first Ad
         loadAppOpenAd()
     }
@@ -80,7 +80,7 @@ class AppOpenAdManager(application: Application) : AppOpenAdLoadListener {
     private fun loadAppOpenAd() {
         // load new Ad if there is no loaded Ad and new ad isn't loading
         if (loadingInProgress.compareAndSet(false, true)) {
-            appOpenAdLoader.loadAd(adRequestConfiguration)
+            appOpenAdLoader.loadAd(adRequest, this)
         }
     }
 

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/ComposeExamplesActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/ComposeExamplesActivity.kt
@@ -1,0 +1,25 @@
+/*
+ * This file is a part of the Yandex Advertising Network
+ *
+ * Version for Android (C) 2026 YANDEX
+ *
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at https://legal.yandex.com/partner_ch/
+ */
+
+package com.yandex.ads.sample.compose
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+
+class ComposeExamplesActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            ComposeExamplesApp()
+        }
+    }
+}

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/ComposeHomeScreen.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/ComposeHomeScreen.kt
@@ -1,0 +1,142 @@
+/*
+ * This file is a part of the Yandex Advertising Network
+ *
+ * Version for Android (C) 2022 YANDEX
+ *
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at https://legal.yandex.com/partner_ch/
+ */
+
+package com.yandex.ads.sample.compose
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.yandex.ads.sample.R
+
+data class ComposeExample(
+    val iconId: Int,
+    val titleId: Int,
+    val route: ComposeRoute
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ComposeHomeScreen(
+    navigate: (ComposeRoute) -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    val examples = listOf(
+        ComposeExample(
+            iconId = R.drawable.ic_outline_ad_units_24,
+            titleId = R.string.sticky_banner_title,
+            route = ComposeRoute.BannerSticky
+        ),
+        ComposeExample(
+            iconId = R.drawable.ic_outline_aspect_ratio_24,
+            titleId = R.string.inline_banner_title,
+            route = ComposeRoute.BannerInline
+        ),
+        ComposeExample(
+            iconId = R.drawable.ic_outline_fullscreen_24,
+            titleId = R.string.interstitial_title,
+            route = ComposeRoute.Interstitial
+        ),
+        ComposeExample(
+            iconId = R.drawable.ic_outline_video_library_24,
+            titleId = R.string.rewarded_title,
+            route = ComposeRoute.Rewarded
+        ),
+        ComposeExample(
+            iconId = R.drawable.ic_full_coverage_24,
+            titleId = R.string.appopenad_title,
+            route = ComposeRoute.AppOpenAd
+        ),
+    )
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Jetpack Compose Examples") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            items(examples) { example ->
+                ExampleCard(
+                    example = example,
+                    onClick = { navigate(example.route) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ExampleCard(
+    example: ComposeExample,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(id = example.iconId),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Text(
+            text = stringResource(id = example.titleId),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 24.dp)
+        )
+
+        Icon(
+            painter = painterResource(id = R.drawable.ic_outline_chevron_right_24),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/ComposeNavigation.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/ComposeNavigation.kt
@@ -1,0 +1,126 @@
+/*
+ * This file is a part of the Yandex Advertising Network
+ *
+ * Version for Android (C) 2022 YANDEX
+ *
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at https://legal.yandex.com/partner_ch/
+ */
+
+package com.yandex.ads.sample.compose
+
+import android.app.Activity
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.yandex.ads.sample.compose.adunits.ComposeBannerInlineScreen
+import com.yandex.ads.sample.compose.adunits.ComposeBannerStickyScreen
+import com.yandex.ads.sample.compose.adunits.ComposeInterstitialScreen
+import com.yandex.ads.sample.compose.adunits.ComposeRewardedScreen
+import com.yandex.ads.sample.compose.adunits.ComposeAppOpenAdScreen
+import kotlinx.serialization.Serializable
+
+sealed interface ComposeRoute {
+    @Serializable
+    data object Home : ComposeRoute
+
+    @Serializable
+    data object BannerSticky : ComposeRoute
+
+    @Serializable
+    data object BannerInline : ComposeRoute
+
+    @Serializable
+    data object Interstitial : ComposeRoute
+
+    @Serializable
+    data object Rewarded : ComposeRoute
+
+    @Serializable
+    data object AppOpenAd : ComposeRoute
+}
+
+@Composable
+fun ComposeExamplesApp() {
+    MaterialTheme {
+        Surface(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                ComposeNavigation()
+            }
+        }
+    }
+}
+
+@Composable
+fun ComposeNavigation() {
+    val navController = rememberNavController()
+    val context = LocalContext.current
+
+    val navigate: (ComposeRoute) -> Unit = { route ->
+        runCatching { navController.navigate(route) }
+    }
+
+    NavHost(
+        navController = navController,
+        startDestination = ComposeRoute.Home,
+        enterTransition = {
+            slideIntoContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Left,
+                animationSpec = tween(300)
+            ) + fadeIn(animationSpec = tween(300))
+        },
+        exitTransition = {
+            slideOutOfContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Left,
+                animationSpec = tween(300)
+            ) + fadeOut(animationSpec = tween(300))
+        },
+        popEnterTransition = {
+            slideIntoContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Right,
+                animationSpec = tween(300)
+            ) + fadeIn(animationSpec = tween(300))
+        },
+        popExitTransition = {
+            slideOutOfContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Right,
+                animationSpec = tween(300)
+            ) + fadeOut(animationSpec = tween(300))
+        }
+    ) {
+        composable<ComposeRoute.Home> {
+            ComposeHomeScreen(
+                navigate = navigate,
+                onNavigateBack = { (context as? Activity)?.finish() }
+            )
+        }
+        composable<ComposeRoute.BannerSticky> {
+            ComposeBannerStickyScreen(onNavigateBack = { navController.navigateUp() })
+        }
+        composable<ComposeRoute.BannerInline> {
+            ComposeBannerInlineScreen(onNavigateBack = { navController.navigateUp() })
+        }
+        composable<ComposeRoute.Interstitial> {
+            ComposeInterstitialScreen(onNavigateBack = { navController.navigateUp() })
+        }
+        composable<ComposeRoute.Rewarded> {
+            ComposeRewardedScreen(onNavigateBack = { navController.navigateUp() })
+        }
+        composable<ComposeRoute.AppOpenAd> {
+            ComposeAppOpenAdScreen(onNavigateBack = { navController.navigateUp() })
+        }
+    }
+}

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeAppOpenAdScreen.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeAppOpenAdScreen.kt
@@ -1,0 +1,167 @@
+/*
+ * This file is a part of the Yandex Advertising Network
+ *
+ * Version for Android (C) 2026 YANDEX
+ *
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at https://legal.yandex.com/partner_ch/
+ */
+
+package com.yandex.ads.sample.compose.adunits
+
+import android.app.Activity
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.yandex.mobile.ads.appopenad.AppOpenAd
+import com.yandex.mobile.ads.appopenad.AppOpenAdEventListener
+import com.yandex.mobile.ads.appopenad.AppOpenAdLoadResult
+import com.yandex.mobile.ads.common.AdError
+import com.yandex.mobile.ads.common.AdRequest
+import com.yandex.mobile.ads.common.ImpressionData
+import com.yandex.mobile.ads.compose.rememberAppOpenAdLoader
+import kotlinx.coroutines.launch
+
+private const val DEFAULT_APP_OPEN_AD_UNIT_ID = "demo-appopenad-yandex"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ComposeAppOpenAdScreen(
+    onNavigateBack: () -> Unit,
+) {
+    var adUnitId by remember { mutableStateOf(DEFAULT_APP_OPEN_AD_UNIT_ID) }
+    var logs by remember { mutableStateOf("") }
+    var loadedAd by remember { mutableStateOf<AppOpenAd?>(null) }
+
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    fun appendLog(message: String) {
+        logs = if (logs.isEmpty()) message else "$logs\n$message"
+    }
+
+    val loader = rememberAppOpenAdLoader()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Compose App Open Ad") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            OutlinedTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = adUnitId,
+                onValueChange = { adUnitId = it },
+                label = { Text("Ad Unit ID") },
+                singleLine = true,
+                textStyle = TextStyle(fontSize = 16.sp),
+            )
+
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    loadedAd = null
+                    appendLog("Loading…")
+                    scope.launch {
+                        when (val result = loader.loadAd(AdRequest.Builder(adUnitId).build())) {
+                            is AppOpenAdLoadResult.Success -> {
+                                loadedAd = result.ad
+                                appendLog("onAdLoaded")
+                            }
+                            is AppOpenAdLoadResult.Failure ->
+                                appendLog("onAdFailedToLoad: ${result.error.description}")
+                        }
+                    }
+                }
+            ) {
+                Text("Load")
+            }
+
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                enabled = loadedAd != null,
+                onClick = {
+                    loadedAd?.let { ad ->
+                        ad.setAdEventListener(object : AppOpenAdEventListener {
+                            override fun onAdShown() { appendLog("onAdShown") }
+                            override fun onAdFailedToShow(e: AdError) {
+                                appendLog("onAdFailedToShow: ${e.description}")
+                            }
+                            override fun onAdDismissed() {
+                                appendLog("onAdDismissed")
+                                loadedAd = null
+                            }
+                            override fun onAdClicked() { appendLog("onAdClicked") }
+                            override fun onAdImpression(data: ImpressionData?) {
+                                appendLog("onAdImpression")
+                            }
+                        })
+                        ad.show(context as Activity)
+                    }
+                }
+            ) {
+                Text("Show")
+            }
+
+            val logWindowScrollState = rememberScrollState()
+
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .height(250.dp)
+                    .border(1.dp, Color.Black, RoundedCornerShape(12.dp))
+                    .verticalScroll(logWindowScrollState)
+                    .padding(12.dp)
+            ) {
+                Text(text = logs, fontSize = 14.sp)
+            }
+        }
+    }
+}

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeBannerInlineScreen.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeBannerInlineScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,6 +46,7 @@ import com.yandex.mobile.ads.common.AdRequest
 import com.yandex.mobile.ads.compose.Banner
 import com.yandex.mobile.ads.compose.BannerEvents
 import com.yandex.mobile.ads.compose.BannerSize
+import com.yandex.mobile.ads.compose.rememberBannerAdState
 
 private const val DEFAULT_BANNER_AD_UNIT_ID = "demo-banner-yandex"
 
@@ -58,6 +60,20 @@ fun ComposeBannerInlineScreen(
 
     fun appendLog(message: String) {
         logs = if (logs.isEmpty()) message else "$logs\n$message"
+    }
+
+    val bannerState = rememberBannerAdState(
+        adSize = BannerSize.Inline(width = 320.dp, maxHeight = 250.dp),
+        events = BannerEvents(
+            onAdLoaded = { _ -> appendLog("onAdLoaded") },
+            onAdFailedToLoad = { error -> appendLog("onAdFailedToLoad: ${error.description}") },
+            onAdClicked = { appendLog("onAdClicked") },
+            onImpression = { appendLog("onImpression") },
+        ),
+    )
+
+    LaunchedEffect(adUnitId) {
+        bannerState.loadAd(AdRequest.Builder(adUnitId).build())
     }
 
     Scaffold(
@@ -106,15 +122,8 @@ fun ComposeBannerInlineScreen(
             }
 
             Banner(
-                adRequest = AdRequest.Builder(adUnitId).build(),
-                adSize = BannerSize.Inline(width = 320, maxHeight = 250),
+                state = bannerState,
                 modifier = Modifier.fillMaxWidth().semantics { testTag = "banner" },
-                events = BannerEvents(
-                    onAdLoaded = { appendLog("onAdLoaded") },
-                    onAdFailedToLoad = { error -> appendLog("onAdFailedToLoad: ${error.description}") },
-                    onAdClicked = { appendLog("onAdClicked") },
-                    onImpression = { appendLog("onImpression") },
-                ),
             )
         }
     }

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeBannerInlineScreen.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeBannerInlineScreen.kt
@@ -1,0 +1,121 @@
+/*
+ * This file is a part of the Yandex Advertising Network
+ *
+ * Version for Android (C) 2026 YANDEX
+ *
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at https://legal.yandex.com/partner_ch/
+ */
+
+package com.yandex.ads.sample.compose.adunits
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.yandex.mobile.ads.common.AdRequest
+import com.yandex.mobile.ads.compose.Banner
+import com.yandex.mobile.ads.compose.BannerEvents
+import com.yandex.mobile.ads.compose.BannerSize
+
+private const val DEFAULT_BANNER_AD_UNIT_ID = "demo-banner-yandex"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ComposeBannerInlineScreen(
+    onNavigateBack: () -> Unit,
+) {
+    var adUnitId by remember { mutableStateOf(DEFAULT_BANNER_AD_UNIT_ID) }
+    var logs by remember { mutableStateOf("") }
+
+    fun appendLog(message: String) {
+        logs = if (logs.isEmpty()) message else "$logs\n$message"
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Compose Banner (Inline)") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            OutlinedTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = adUnitId,
+                onValueChange = { adUnitId = it },
+                label = { Text("Ad Unit ID") },
+                singleLine = true,
+                textStyle = TextStyle(fontSize = 16.sp),
+            )
+
+            val logWindowScrollState = rememberScrollState()
+
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .height(120.dp)
+                    .border(1.dp, Color.Black, RoundedCornerShape(12.dp))
+                    .verticalScroll(logWindowScrollState)
+                    .padding(12.dp)
+            ) {
+                Text(text = logs, fontSize = 14.sp)
+            }
+
+            Banner(
+                adRequest = AdRequest.Builder(adUnitId).build(),
+                adSize = BannerSize.Inline(width = 320, maxHeight = 250),
+                modifier = Modifier.fillMaxWidth().semantics { testTag = "banner" },
+                events = BannerEvents(
+                    onAdLoaded = { appendLog("onAdLoaded") },
+                    onAdFailedToLoad = { error -> appendLog("onAdFailedToLoad: ${error.description}") },
+                    onAdClicked = { appendLog("onAdClicked") },
+                    onImpression = { appendLog("onImpression") },
+                ),
+            )
+        }
+    }
+}

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeBannerStickyScreen.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeBannerStickyScreen.kt
@@ -1,0 +1,121 @@
+/*
+ * This file is a part of the Yandex Advertising Network
+ *
+ * Version for Android (C) 2026 YANDEX
+ *
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at https://legal.yandex.com/partner_ch/
+ */
+
+package com.yandex.ads.sample.compose.adunits
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.yandex.mobile.ads.common.AdRequest
+import com.yandex.mobile.ads.compose.Banner
+import com.yandex.mobile.ads.compose.BannerEvents
+import com.yandex.mobile.ads.compose.BannerSize
+
+private const val DEFAULT_BANNER_AD_UNIT_ID = "demo-banner-yandex"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ComposeBannerStickyScreen(
+    onNavigateBack: () -> Unit,
+) {
+    var adUnitId by remember { mutableStateOf(DEFAULT_BANNER_AD_UNIT_ID) }
+    var logs by remember { mutableStateOf("") }
+
+    fun appendLog(message: String) {
+        logs = if (logs.isEmpty()) message else "$logs\n$message"
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Compose Banner (Sticky)") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            OutlinedTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = adUnitId,
+                onValueChange = { adUnitId = it },
+                label = { Text("Ad Unit ID") },
+                singleLine = true,
+                textStyle = TextStyle(fontSize = 16.sp),
+            )
+
+            val logWindowScrollState = rememberScrollState()
+
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .height(120.dp)
+                    .border(1.dp, Color.Black, RoundedCornerShape(12.dp))
+                    .verticalScroll(logWindowScrollState)
+                    .padding(12.dp)
+            ) {
+                Text(text = logs, fontSize = 14.sp)
+            }
+
+            Banner(
+                adRequest = AdRequest.Builder(adUnitId).build(),
+                adSize = BannerSize.Sticky(width = 320),
+                modifier = Modifier.fillMaxWidth().semantics { testTag = "banner" },
+                events = BannerEvents(
+                    onAdLoaded = { appendLog("onAdLoaded") },
+                    onAdFailedToLoad = { error -> appendLog("onAdFailedToLoad: ${error.description}") },
+                    onAdClicked = { appendLog("onAdClicked") },
+                    onImpression = { appendLog("onImpression") },
+                ),
+            )
+        }
+    }
+}

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeBannerStickyScreen.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeBannerStickyScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,6 +46,7 @@ import com.yandex.mobile.ads.common.AdRequest
 import com.yandex.mobile.ads.compose.Banner
 import com.yandex.mobile.ads.compose.BannerEvents
 import com.yandex.mobile.ads.compose.BannerSize
+import com.yandex.mobile.ads.compose.rememberBannerAdState
 
 private const val DEFAULT_BANNER_AD_UNIT_ID = "demo-banner-yandex"
 
@@ -58,6 +60,20 @@ fun ComposeBannerStickyScreen(
 
     fun appendLog(message: String) {
         logs = if (logs.isEmpty()) message else "$logs\n$message"
+    }
+
+    val bannerState = rememberBannerAdState(
+        adSize = BannerSize.Sticky(width = 320.dp),
+        events = BannerEvents(
+            onAdLoaded = { _ -> appendLog("onAdLoaded") },
+            onAdFailedToLoad = { error -> appendLog("onAdFailedToLoad: ${error.description}") },
+            onAdClicked = { appendLog("onAdClicked") },
+            onImpression = { appendLog("onImpression") },
+        ),
+    )
+
+    LaunchedEffect(adUnitId) {
+        bannerState.loadAd(AdRequest.Builder(adUnitId).build())
     }
 
     Scaffold(
@@ -106,15 +122,8 @@ fun ComposeBannerStickyScreen(
             }
 
             Banner(
-                adRequest = AdRequest.Builder(adUnitId).build(),
-                adSize = BannerSize.Sticky(width = 320),
+                state = bannerState,
                 modifier = Modifier.fillMaxWidth().semantics { testTag = "banner" },
-                events = BannerEvents(
-                    onAdLoaded = { appendLog("onAdLoaded") },
-                    onAdFailedToLoad = { error -> appendLog("onAdFailedToLoad: ${error.description}") },
-                    onAdClicked = { appendLog("onAdClicked") },
-                    onImpression = { appendLog("onImpression") },
-                ),
             )
         }
     }

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeInterstitialScreen.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeInterstitialScreen.kt
@@ -1,0 +1,165 @@
+/*
+ * This file is a part of the Yandex Advertising Network
+ *
+ * Version for Android (C) 2026 YANDEX
+ *
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at https://legal.yandex.com/partner_ch/
+ */
+
+package com.yandex.ads.sample.compose.adunits
+
+import android.app.Activity
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.yandex.mobile.ads.common.AdRequest
+import com.yandex.mobile.ads.compose.rememberInterstitialAdLoader
+import com.yandex.mobile.ads.interstitial.InterstitialAd
+import com.yandex.mobile.ads.interstitial.InterstitialAdEventListener
+import com.yandex.mobile.ads.interstitial.InterstitialAdLoadResult
+import kotlinx.coroutines.launch
+
+private const val DEFAULT_INTERSTITIAL_AD_UNIT_ID = "demo-interstitial-yandex"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ComposeInterstitialScreen(
+    onNavigateBack: () -> Unit,
+) {
+    var adUnitId by remember { mutableStateOf(DEFAULT_INTERSTITIAL_AD_UNIT_ID) }
+    var logs by remember { mutableStateOf("") }
+    var loadedAd by remember { mutableStateOf<InterstitialAd?>(null) }
+
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    fun appendLog(message: String) {
+        logs = if (logs.isEmpty()) message else "$logs\n$message"
+    }
+
+    val loader = rememberInterstitialAdLoader()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Compose Interstitial") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            OutlinedTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = adUnitId,
+                onValueChange = { adUnitId = it },
+                label = { Text("Ad Unit ID") },
+                singleLine = true,
+                textStyle = TextStyle(fontSize = 16.sp),
+            )
+
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    loadedAd = null
+                    appendLog("Loading…")
+                    scope.launch {
+                        when (val result = loader.loadAd(AdRequest.Builder(adUnitId).build())) {
+                            is InterstitialAdLoadResult.Success -> {
+                                loadedAd = result.ad
+                                appendLog("onAdLoaded")
+                            }
+                            is InterstitialAdLoadResult.Failure ->
+                                appendLog("onAdFailedToLoad: ${result.error.description}")
+                        }
+                    }
+                }
+            ) {
+                Text("Load")
+            }
+
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                enabled = loadedAd != null,
+                onClick = {
+                    loadedAd?.let { ad ->
+                        ad.setAdEventListener(object : InterstitialAdEventListener {
+                            override fun onAdShown() { appendLog("onAdShown") }
+                            override fun onAdFailedToShow(e: com.yandex.mobile.ads.common.AdError) {
+                                appendLog("onAdFailedToShow: ${e.description}")
+                            }
+                            override fun onAdDismissed() {
+                                appendLog("onAdDismissed")
+                                loadedAd = null
+                            }
+                            override fun onAdClicked() { appendLog("onAdClicked") }
+                            override fun onAdImpression(data: com.yandex.mobile.ads.common.ImpressionData?) {
+                                appendLog("onAdImpression")
+                            }
+                        })
+                        ad.show(context as Activity)
+                    }
+                }
+            ) {
+                Text("Show")
+            }
+
+            val logWindowScrollState = rememberScrollState()
+
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .height(250.dp)
+                    .border(1.dp, Color.Black, RoundedCornerShape(12.dp))
+                    .verticalScroll(logWindowScrollState)
+                    .padding(12.dp)
+            ) {
+                Text(text = logs, fontSize = 14.sp)
+            }
+        }
+    }
+}

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeRewardedScreen.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/compose/adunits/ComposeRewardedScreen.kt
@@ -1,0 +1,171 @@
+/*
+ * This file is a part of the Yandex Advertising Network
+ *
+ * Version for Android (C) 2026 YANDEX
+ *
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at https://legal.yandex.com/partner_ch/
+ */
+
+package com.yandex.ads.sample.compose.adunits
+
+import android.app.Activity
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.yandex.mobile.ads.common.AdError
+import com.yandex.mobile.ads.common.AdRequest
+import com.yandex.mobile.ads.common.ImpressionData
+import com.yandex.mobile.ads.compose.rememberRewardedAdLoader
+import com.yandex.mobile.ads.rewarded.Reward
+import com.yandex.mobile.ads.rewarded.RewardedAd
+import com.yandex.mobile.ads.rewarded.RewardedAdEventListener
+import com.yandex.mobile.ads.rewarded.RewardedAdLoadResult
+import kotlinx.coroutines.launch
+
+private const val DEFAULT_REWARDED_AD_UNIT_ID = "demo-rewarded-yandex"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ComposeRewardedScreen(
+    onNavigateBack: () -> Unit,
+) {
+    var adUnitId by remember { mutableStateOf(DEFAULT_REWARDED_AD_UNIT_ID) }
+    var logs by remember { mutableStateOf("") }
+    var loadedAd by remember { mutableStateOf<RewardedAd?>(null) }
+
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    fun appendLog(message: String) {
+        logs = if (logs.isEmpty()) message else "$logs\n$message"
+    }
+
+    val loader = rememberRewardedAdLoader()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Compose Rewarded") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            OutlinedTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = adUnitId,
+                onValueChange = { adUnitId = it },
+                label = { Text("Ad Unit ID") },
+                singleLine = true,
+                textStyle = TextStyle(fontSize = 16.sp),
+            )
+
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    loadedAd = null
+                    appendLog("Loading…")
+                    scope.launch {
+                        when (val result = loader.loadAd(AdRequest.Builder(adUnitId).build())) {
+                            is RewardedAdLoadResult.Success -> {
+                                loadedAd = result.ad
+                                appendLog("onAdLoaded")
+                            }
+                            is RewardedAdLoadResult.Failure ->
+                                appendLog("onAdFailedToLoad: ${result.error.description}")
+                        }
+                    }
+                }
+            ) {
+                Text("Load")
+            }
+
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                enabled = loadedAd != null,
+                onClick = {
+                    loadedAd?.let { ad ->
+                        ad.setAdEventListener(object : RewardedAdEventListener {
+                            override fun onAdShown() { appendLog("onAdShown") }
+                            override fun onAdFailedToShow(e: AdError) {
+                                appendLog("onAdFailedToShow: ${e.description}")
+                            }
+                            override fun onAdDismissed() {
+                                appendLog("onAdDismissed")
+                                loadedAd = null
+                            }
+                            override fun onAdClicked() { appendLog("onAdClicked") }
+                            override fun onAdImpression(data: ImpressionData?) {
+                                appendLog("onAdImpression")
+                            }
+                            override fun onRewarded(reward: Reward) {
+                                appendLog("onRewarded: type=${reward.type} amount=${reward.amount}")
+                            }
+                        })
+                        ad.show(context as Activity)
+                    }
+                }
+            ) {
+                Text("Show")
+            }
+
+            val logWindowScrollState = rememberScrollState()
+
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .height(250.dp)
+                    .border(1.dp, Color.Black, RoundedCornerShape(12.dp))
+                    .verticalScroll(logWindowScrollState)
+                    .padding(12.dp)
+            ) {
+                Text(text = logs, fontSize = 14.sp)
+            }
+        }
+    }
+}

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/nativeads/NativeAdBannerView.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/nativeads/NativeAdBannerView.kt
@@ -1,0 +1,46 @@
+package com.yandex.ads.sample.nativeads
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import androidx.core.view.isVisible
+import com.yandex.ads.sample.databinding.NativeBannerAdViewBinding
+import com.yandex.mobile.ads.common.AdBindingResult
+import com.yandex.mobile.ads.nativeads.NativeAd
+import com.yandex.mobile.ads.nativeads.NativeAdViewBinder
+
+class NativeAdBannerView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private val binding = NativeBannerAdViewBinding.inflate(LayoutInflater.from(context), this, true)
+
+    fun bindNativeAd(nativeAd: NativeAd) {
+        val binder = binding.run {
+            NativeAdViewBinder.Builder(nativeAdContainer)
+                .setAgeView(age)
+                .setBodyView(body)
+                .setCallToActionView(callToAction)
+                .setDomainView(domain)
+                .setFaviconView(favicon)
+                .setFeedbackView(feedback)
+                .setIconView(icon)
+                .setMediaView(media)
+                .setPriceView(price)
+                .setRatingView(rating)
+                .setReviewCountView(reviewCount)
+                .setSponsoredView(sponsored)
+                .setTitleView(title)
+                .setWarningView(warning)
+                .build()
+        }
+        isVisible = nativeAd.bindNativeAd(binder) is AdBindingResult.Success
+    }
+
+    fun release() {
+        isVisible = false
+    }
+}

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/navigation/NavigationItem.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/navigation/NavigationItem.kt
@@ -14,7 +14,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import com.yandex.mobile.ads.common.MobileAds
+import com.yandex.mobile.ads.common.YandexAds
 
 data class NavigationItem(
     @DrawableRes val iconId: Int,
@@ -29,7 +29,7 @@ data class NavigationItem(
             }
 
             is NavigationType.DebugPanelNavigation -> {
-                MobileAds.showDebugPanel(context)
+                YandexAds.showDebugPanel(context)
             }
         }
     }

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/player/ad/SampleInstreamAdPlayer.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/player/ad/SampleInstreamAdPlayer.kt
@@ -9,10 +9,13 @@
 
 package com.yandex.ads.sample.player.ad
 
+import android.widget.FrameLayout
 import androidx.media3.ui.PlayerView
+import com.google.android.exoplayer2.ui.StyledPlayerView
 import com.yandex.ads.sample.player.SamplePlayer
 import com.yandex.mobile.ads.instream.player.ad.InstreamAdPlayer
 import com.yandex.mobile.ads.instream.player.ad.InstreamAdPlayerListener
+import com.yandex.mobile.ads.instream.player.ad.InstreamAdMimeTypes
 import com.yandex.mobile.ads.video.playback.model.VideoAd
 
 class SampleInstreamAdPlayer(
@@ -23,6 +26,9 @@ class SampleInstreamAdPlayer(
 
     private var currentVideoAd: VideoAd? = null
     private var adPlayerListener: InstreamAdPlayerListener? = null
+
+    override val supportedMimeTypes: List<String>
+        get() = listOf(InstreamAdMimeTypes.MP4, InstreamAdMimeTypes.WEBM)
 
     override fun setInstreamAdPlayerListener(instreamAdPlayerListener: InstreamAdPlayerListener?) {
         adPlayerListener = instreamAdPlayerListener
@@ -64,6 +70,18 @@ class SampleInstreamAdPlayer(
 
     override fun getVolume(videoAd: VideoAd): Float {
         return adPlayers[videoAd]?.getVolume() ?: DEFAULT_VOLUME
+    }
+
+    override fun bindPlayerView(container: FrameLayout) {
+        val playerView = createPlayerView(container)
+        container.addView(playerView)
+    }
+
+    private fun createPlayerView(container: FrameLayout): StyledPlayerView {
+        val playerView = StyledPlayerView(container.context)
+        return playerView.apply {
+            useController = false
+        }
     }
 
     override fun getAdDuration(videoAd: VideoAd): Long {

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/settings/PoliciesActivity.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/settings/PoliciesActivity.kt
@@ -20,7 +20,7 @@ import com.yandex.ads.sample.databinding.ActivityPoliciesBinding
 import com.yandex.ads.sample.policy.PolicyAdapter
 import com.yandex.ads.sample.policy.PolicyItem
 import com.yandex.ads.sample.utils.applySystemBarsPadding
-import com.yandex.mobile.ads.common.MobileAds
+import com.yandex.mobile.ads.common.YandexAds
 
 class PoliciesActivity : AppCompatActivity(R.layout.activity_policies) {
 
@@ -51,7 +51,7 @@ class PoliciesActivity : AppCompatActivity(R.layout.activity_policies) {
                 R.string.gdpr_enabled,
                 GdprDialogFragment.TAG,
                 ::GdprDialogFragment,
-                MobileAds::setUserConsent,
+                YandexAds::setUserConsent,
             ),
             PolicyItem(
                 R.drawable.ic_outline_place_24,
@@ -59,7 +59,7 @@ class PoliciesActivity : AppCompatActivity(R.layout.activity_policies) {
                 R.string.location_enabled,
                 LocationDialogFragment.TAG,
                 ::LocationDialogFragment,
-                MobileAds::setLocationConsent,
+                YandexAds::setLocationTracking,
             ),
             PolicyItem(
                 R.drawable.ic_outline_child_care_24,
@@ -67,7 +67,7 @@ class PoliciesActivity : AppCompatActivity(R.layout.activity_policies) {
                 R.string.coppa_enabled,
                 CoppaDialogFragment.TAG,
                 ::CoppaDialogFragment,
-                MobileAds::setAgeRestrictedUser,
+                YandexAds::setAgeRestricted,
             ),
         )
     }

--- a/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/tv/instream/player/TvInstreamPlayer.kt
+++ b/YandexMobileAdsExample/app/src/main/java/com/yandex/ads/sample/tv/instream/player/TvInstreamPlayer.kt
@@ -16,7 +16,7 @@ import com.yandex.ads.sample.R
 import com.yandex.ads.sample.tv.instream.player.model.ContentType
 import com.yandex.ads.sample.tv.instream.player.model.ErrorType
 import com.yandex.ads.sample.tv.instream.player.model.TvInstreamPlayerState
-import com.yandex.mobile.ads.instream.InstreamAdRequestConfiguration
+import com.yandex.mobile.ads.instream.InstreamAdRequest
 import com.yandex.mobile.ads.instream.media3.YandexAdsLoader
 import com.yandex.mobile.ads.video.playback.VideoAdPlaybackListener
 import com.yandex.mobile.ads.video.playback.model.VideoAd
@@ -139,7 +139,7 @@ class TvInstreamPlayer(
     }
 
     private fun initAdsLoader() {
-        val configuration = InstreamAdRequestConfiguration
+        val configuration = InstreamAdRequest
             .Builder(adUnitId)
             .build()
         yandexAdsLoader = YandexAdsLoader(context, configuration)

--- a/YandexMobileAdsExample/app/src/main/res/layout/activity_native_template_ad.xml
+++ b/YandexMobileAdsExample/app/src/main/res/layout/activity_native_template_ad.xml
@@ -37,18 +37,18 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintTop_toBottomOf="@id/toolbar"
-        app:layout_constraintBottom_toTopOf="@id/native_banner"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintVertical_chainStyle="spread_inside"
         tools:layout="@layout/fragment_ad_info" />
+<!--        app:layout_constraintBottom_toTopOf="@id/native_banner"-->
 
-    <com.yandex.mobile.ads.nativeads.template.NativeBannerView
-        android:id="@+id/native_banner"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:layout_constraintTop_toBottomOf="@id/ad_info"
-        app:layout_constraintBottom_toBottomOf="parent" />
+<!--    <com.yandex.mobile.ads.nativeads.template.NativeBannerView-->
+<!--        android:id="@+id/native_banner"-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:visibility="gone"-->
+<!--        app:layout_constraintTop_toBottomOf="@id/ad_info"-->
+<!--        app:layout_constraintBottom_toBottomOf="parent" />-->
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/YandexMobileAdsExample/app/src/main/res/layout/activity_native_template_ad.xml
+++ b/YandexMobileAdsExample/app/src/main/res/layout/activity_native_template_ad.xml
@@ -37,18 +37,18 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintBottom_toTopOf="@id/native_banner"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintVertical_chainStyle="spread_inside"
         tools:layout="@layout/fragment_ad_info" />
-<!--        app:layout_constraintBottom_toTopOf="@id/native_banner"-->
 
-<!--    <com.yandex.mobile.ads.nativeads.template.NativeBannerView-->
-<!--        android:id="@+id/native_banner"-->
-<!--        android:layout_width="match_parent"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        android:visibility="gone"-->
-<!--        app:layout_constraintTop_toBottomOf="@id/ad_info"-->
-<!--        app:layout_constraintBottom_toBottomOf="parent" />-->
+    <com.yandex.ads.sample.nativeads.NativeAdBannerView
+        android:id="@+id/native_banner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/ad_info"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/YandexMobileAdsExample/app/src/main/res/layout/native_banner_ad_view.xml
+++ b/YandexMobileAdsExample/app/src/main/res/layout/native_banner_ad_view.xml
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ This file is a part of the Yandex Advertising Network
+  ~
+  ~ Version for Android (C) 2025 YANDEX
+  ~
+  ~ You may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at https://legal.yandex.com/partner_ch/
+  -->
+
+<com.yandex.mobile.ads.nativeads.NativeAdView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/native_ad_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <!-- Top row: age | sponsored | feedback -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/native_ad_template_offset"
+            android:layout_marginLeft="@dimen/native_ad_template_offset"
+            android:layout_marginTop="@dimen/native_offset_medium"
+            android:layout_marginEnd="@dimen/native_ad_template_offset"
+            android:layout_marginRight="@dimen/native_ad_template_offset"
+            android:layout_marginBottom="@dimen/native_offset_small"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:weightSum="4">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1">
+
+                <TextView
+                    android:id="@+id/age"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="start"
+                    android:maxLines="1"
+                    android:textColor="@color/base_asset_text_color"
+                    android:visibility="gone"
+                    tools:text="18+"
+                    tools:visibility="visible" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="2"
+                android:gravity="center">
+
+                <TextView
+                    android:id="@+id/sponsored"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:gravity="center"
+                    android:maxLines="1"
+                    android:textColor="@color/base_asset_text_color"
+                    android:textSize="@dimen/native_asset_text_size_small"
+                    android:visibility="gone"
+                    tools:text="Ad"
+                    tools:visibility="visible" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="end">
+
+                <ImageView
+                    android:id="@+id/feedback"
+                    android:layout_width="@dimen/native_feedback_width"
+                    android:layout_height="@dimen/native_feedback_height"
+                    android:padding="4dp"
+                    android:src="@drawable/close_button"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <!-- Center row: icon + content (title, body, domain, cta) -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/native_offset_small"
+            android:layout_marginEnd="@dimen/native_ad_template_offset"
+            android:layout_marginLeft="@dimen/native_ad_template_offset"
+            android:layout_marginRight="@dimen/native_ad_template_offset"
+            android:layout_marginStart="@dimen/native_ad_template_offset"
+            android:baselineAligned="false"
+            android:orientation="horizontal">
+
+            <!-- Icon -->
+            <FrameLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/native_ad_template_offset"
+                android:layout_marginRight="@dimen/native_ad_template_offset"
+                android:layout_marginTop="@dimen/native_offset_small">
+
+                <ImageView
+                    android:id="@+id/icon"
+                    android:layout_width="@dimen/native_image_width"
+                    android:layout_height="@dimen/native_image_height"
+                    android:adjustViewBounds="true"
+                    android:scaleType="centerCrop"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+            </FrameLayout>
+
+            <!-- Content -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:maxLines="@integer/asset_title_max_lines"
+                    android:textColor="@android:color/black"
+                    android:textSize="@dimen/native_asset_text_size_large"
+                    android:textStyle="bold"
+                    android:visibility="gone"
+                    tools:text="Ad title"
+                    tools:visibility="visible" />
+
+                <TextView
+                    android:id="@+id/body"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:maxLines="@integer/asset_body_max_lines"
+                    android:textColor="@android:color/black"
+                    android:textSize="@dimen/native_asset_text_size_medium"
+                    android:visibility="gone"
+                    tools:text="Ad body text describing the product"
+                    tools:visibility="visible" />
+
+                <!-- Favicon + domain -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <ImageView
+                        android:id="@+id/favicon"
+                        android:layout_width="@dimen/native_favicon_width"
+                        android:layout_height="@dimen/native_favicon_height"
+                        android:layout_marginEnd="@dimen/native_offset_small"
+                        android:layout_marginRight="@dimen/native_offset_small"
+                        android:adjustViewBounds="true"
+                        android:scaleType="centerCrop"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
+
+                    <TextView
+                        android:id="@+id/domain"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:maxLines="@integer/asset_domain_max_lines"
+                        android:textColor="@color/base_asset_text_color"
+                        android:textSize="@dimen/native_asset_text_size_medium"
+                        android:visibility="gone"
+                        tools:text="example.com"
+                        tools:visibility="visible" />
+
+                </LinearLayout>
+
+                <!-- Price / rating / review count + CTA -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <!-- Price, rating, review count -->
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/price"
+                            style="@style/TextAppearance.AppCompat.Small"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textStyle="bold"
+                            android:visibility="gone"
+                            tools:text="$0.99"
+                            tools:visibility="visible" />
+
+                        <com.yandex.ads.sample.common.RatingView
+                            android:id="@+id/rating"
+                            style="?android:attr/ratingBarStyleSmall"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginEnd="@dimen/native_offset_medium"
+                            android:layout_marginRight="@dimen/native_offset_medium"
+                            android:numStars="5"
+                            android:stepSize="0.5"
+                            android:visibility="gone"
+                            tools:visibility="visible" />
+
+                        <TextView
+                            android:id="@+id/review_count"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:ellipsize="end"
+                            android:maxLines="@integer/asset_review_count_max_lines"
+                            android:textColor="@color/base_asset_text_color"
+                            android:textSize="@dimen/native_asset_text_size_medium"
+                            android:visibility="gone"
+                            tools:text="1.2k reviews"
+                            tools:visibility="visible" />
+
+                    </LinearLayout>
+
+                    <!-- CTA button -->
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:gravity="end"
+                        android:orientation="horizontal">
+
+                        <TextView
+                            android:id="@+id/call_to_action"
+                            style="@style/Widget.AppCompat.Button.Borderless"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:background="@drawable/call_to_action_background"
+                            android:ellipsize="end"
+                            android:maxLines="@integer/asset_call_to_action_max_lines"
+                            android:minHeight="@dimen/call_to_action_asset_min_height"
+                            android:textAllCaps="false"
+                            android:textSize="@dimen/native_asset_text_size_medium"
+                            android:visibility="gone"
+                            tools:text="Install"
+                            tools:visibility="visible" />
+
+                    </LinearLayout>
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <!-- Media -->
+        <com.yandex.mobile.ads.nativeads.MediaView
+            android:id="@+id/media"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/native_offset_small"
+            android:layout_marginTop="@dimen/native_offset_small"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+        <!-- Warning -->
+        <TextView
+            android:id="@+id/warning"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/warning_background"
+            android:ellipsize="end"
+            android:paddingLeft="@dimen/native_ad_template_offset"
+            android:paddingRight="@dimen/native_ad_template_offset"
+            android:paddingTop="@dimen/native_offset_small"
+            android:textColor="@color/base_asset_text_color"
+            android:textSize="@dimen/native_asset_text_size_medium"
+            android:visibility="gone"
+            tools:text="Warning text"
+            tools:visibility="visible" />
+
+    </LinearLayout>
+
+</com.yandex.mobile.ads.nativeads.NativeAdView>

--- a/YandexMobileAdsExample/app/src/main/res/values/dimens.xml
+++ b/YandexMobileAdsExample/app/src/main/res/values/dimens.xml
@@ -19,11 +19,14 @@
     <dimen name="native_offset_small">4dp</dimen>
     <dimen name="native_offset_medium">8dp</dimen>
     <dimen name="native_offset_large">16dp</dimen>
+    <dimen name="native_ad_template_offset">10dp</dimen>
 
     <dimen name="native_image_height">80dp</dimen>
     <dimen name="native_image_width">80dp</dimen>
     <dimen name="native_favicon_height">16dp</dimen>
     <dimen name="native_favicon_width">16dp</dimen>
+    <dimen name="native_feedback_height">24dp</dimen>
+    <dimen name="native_feedback_width">24dp</dimen>
 
     <dimen name="native_asset_text_size_small">11sp</dimen>
     <dimen name="native_asset_text_size_medium">13sp</dimen>

--- a/YandexMobileAdsExample/app/src/main/res/values/strings.xml
+++ b/YandexMobileAdsExample/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="app_name">Yandex Mobile Ads</string>
 
     <!--  Ad units  -->
+    <string name="compose_examples_title">Jetpack Compose Examples</string>
     <string name="sticky_banner_title">Sticky banner</string>
     <string name="inline_banner_title">Inline banner</string>
     <string name="interstitial_title">Interstitial</string>

--- a/YandexMobileAdsExample/build.gradle.kts
+++ b/YandexMobileAdsExample/build.gradle.kts
@@ -14,7 +14,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:8.9.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/YandexMobileAdsExample/skills/migrate-yandex-ads-sdk-from-7-to-8/README.md
+++ b/YandexMobileAdsExample/skills/migrate-yandex-ads-sdk-from-7-to-8/README.md
@@ -1,0 +1,18 @@
+# Migration to Yandex Mobile Ads SDK 8
+
+**Step 1: Load the skill**
+
+- **For Claude Desktop**
+
+  Copy a folder `skills/migrate-yandex-ads-sdk-from-7-to-8` under directory of your agent like `.cursor/skills/` for Cursor.
+
+- **For Cursor IDE**
+
+  Copy a folder `skills/migrate-yandex-ads-sdk-from-7-to-8` under directory of your agent like `.claude/skills/` for Claude.
+
+**Step 2: Use the prompt**
+
+In your AI chat, attach the skill and run:
+```
+Migrate my project to Yandex Mobile Ads SDK 8.0.0 using the rules from the file @migrate-yandex-ads-sdk-from-7-to-8/SKILL.md
+```

--- a/YandexMobileAdsExample/skills/migrate-yandex-ads-sdk-from-7-to-8/SKILL.md
+++ b/YandexMobileAdsExample/skills/migrate-yandex-ads-sdk-from-7-to-8/SKILL.md
@@ -1,0 +1,422 @@
+# AI Migration Agent Instructions for the Yandex Mobile Ads SDK
+
+## Efficient Migration Strategy
+
+### General StrReplace Rules
+To avoid tool errors when modifying files:
+1. **Include surrounding context**: Add 1-2 lines before/after for unique matching.
+2. **Match exact whitespace**: Preserve all indentation, spaces, newlines exactly.
+3. **One logical change per operation**: Don't combine multiple unrelated edits.
+4. **Use unique anchors**: Include unique variable/method names or comments.
+5. **Verify uniqueness**: Ensure pattern matches only ONE location in file.
+6. **Mark manual changes**: Whenever you add new code, layouts, or modify logic during the migration, ALWAYS add a comment `// FIXME_SDK8: Auto-generated during migration, please review.` (or `<!-- FIXME_SDK8: Auto-generated during migration, please review. -->` in XML) to indicate that this code was auto-generated and requires manual review.
+
+### Migration Sequence:
+
+## STEP 0: Update Yandex Ads SDK dependencies
+
+Use latest available versions in repositories :
+- Core SDK: [https://repo.maven.apache.org/maven2/com/yandex/android/mobileads/](https://repo.maven.apache.org/maven2/com/yandex/android/mobileads/)
+- Mediation bundle: [https://repo.maven.apache.org/maven2/com/yandex/android/mobileads-mediation/](https://repo.maven.apache.org/maven2/com/yandex/android/mobileads-mediation/)
+- Mediation adapters: [https://repo.maven.apache.org/maven2/com/yandex/ads/mediation/](https://repo.maven.apache.org/maven2/com/yandex/ads/mediation/)
+
+#### STEP 1: Identify Application Package (MANDATORY - CANNOT SKIP)
+Read `app/build.gradle.kts` and find `namespace` value (e.g., `"com.yandex.ads.sample"`).
+
+CRITICAL: Any import starting with this namespace is application code, NOT SDK code.
+NEVER replace imports that start with the application namespace.
+
+#### STEP 2: Bulk Import Replacement
+Replace SDK imports ONE BY ONE using bulk find-and-replace (e.g., one command per import).
+Only process lines that do NOT start with application namespace.
+
+**How to replace imports:**
+- Extract the old and new package/class paths from the **Complete Package Structure (SDK 8)** and **Class Mapping** tables below.
+- Replace imports ONE AT A TIME with surrounding context.
+- Include a blank line or the next import for context to ensure uniqueness.
+- Never replace multiple imports in one operation or combine with code changes.
+
+Use IDE's "Replace in Path" feature or command-line tools (sed, PowerShell, etc.)
+
+#### STEP 3: Bulk Simple API & Removed Classes Replacement
+Replace simple class/method names ONE BY ONE using bulk find-and-replace (e.g., one command per API):
+
+**How to replace APIs/Classes:**
+- Replace ONE method call or class name at a time.
+- Include surrounding code (variable declaration, next line, type declaration, assignment) for context.
+- Preserve original variable names.
+
+Replace patterns:
+- `MobileAds.initialize` → `YandexAds.initialize`
+- `AdRequestConfiguration.Builder` → `AdRequest.Builder`
+- `ClosableBannerAdEventListener` → `BannerAdEventListener`
+- `MobileInstream` → `YandexInstreamAds`
+- `BannerAdSize.stickySize` → `BannerAdSize.sticky`
+- `BannerAdSize.inlineSize` → `BannerAdSize.inline`
+
+Use IDE's "Replace in Path" feature or command-line tools (sed, PowerShell, etc.)
+
+Optional: If possible, perform STEP 2 and STEP 3 in parallel in one response (both commands are independent). If not, perform sequentially.
+
+Do not start the build.
+
+#### STEP 4: Replace Native Templates
+
+`NativeBannerView` (with `NativeTemplateAppearance`) was a ready-made template removed in SDK 8. The SDK now requires a custom native ad view: `NativeAdView` as the root container + `NativeAdViewBinder` to bind assets to child views.
+
+**Ready-to-use replacement:** The Yandex Mobile Ads public sample (`YandexMobileAdsExample`) provides a complete drop-in implementation. Read the following files from the sample and create them in the partner's project, replacing the sample package `com.yandex.ads.sample` with the app namespace from STEP 1:
+- `app/src/main/java/com/yandex/ads/sample/nativeads/NativeAdBannerView.kt` — a custom `FrameLayout` that wires up all native ad asset views via `NativeAdViewBinder`
+- `app/src/main/java/com/yandex/ads/sample/common/RatingView.kt` — a `RatingBar` that implements the SDK's `Rating` interface; place it alongside `NativeAdBannerView.kt` and update its package
+- `app/src/main/res/layout/native_banner_ad_view.xml` — the full XML layout; update the `RatingView` class reference to match the new package
+
+Add `//FIXME(SDK8): Auto-generated during migration, please review.` to the top of each copied Kotlin file.
+
+Migration Actions:
+1. **Extract customizations first**: Search for `NativeTemplateAppearance`, `ButtonAppearance`, `TextAppearance`, `ImageAppearance`, `RatingAppearance`, `SizeConstraint` usages and `app:appearance` in XML. Note the values — you will apply them to the new layout in step 3.
+2. **Delete old appearance builder code**: Remove all usages of the builders listed above after extracting the values.
+3. **Apply customizations to `native_banner_ad_view.xml`**: For each value extracted in step 1, set the equivalent XML attribute on the corresponding view. If `app:appearance="@style/..."` was used, open that style to extract values first.
+
+| Old customization | View `@id` | XML attribute |
+|---|---|---|
+| `withTitleAppearance` → `withTextColor` / `withTextSize` | `title` | `android:textColor` / `android:textSize` |
+| `withBodyAppearance` → `withTextColor` / `withTextSize` | `body` | `android:textColor` / `android:textSize` |
+| `withCallToActionAppearance` → `withTextColor` / `withNormalColor` / `withTextSize` | `call_to_action` | `android:textColor` / `android:backgroundTint` / `android:textSize` |
+| `withIconAppearance` → `withWidth` / `withHeight` | `icon` | `android:layout_width` / `android:layout_height` |
+| `withRatingAppearance` → `withStarColor` | `rating` | `android:progressTint` |
+| `withDomainAppearance` → `withTextColor` / `withTextSize` | `domain` | `android:textColor` / `android:textSize` |
+| `withSponsoredAppearance` → `withTextColor` | `sponsored` | `android:textColor` |
+| `withWarningAppearance` → `withTextColor` | `warning` | `android:textColor` |
+| `SizeConstraint` on root | `native_ad_container` | `android:layout_width` / `android:minHeight` |
+
+4. **Replace `NativeBannerView` in XML** with `NativeAdBannerView` (using the partner's app package). Remove the `app:appearance` attribute. Keep `android:id` and all layout parameters.
+5. **Update Kotlin/Java code**:
+   - Replace `nativeBannerView.setAd(nativeAd)` → `nativeBannerView.bindNativeAd(nativeAd)`
+   - Add `nativeBannerView.release()` before each new load and in `onDestroy()`
+
+Do not start the build.
+
+#### STEP 5: First Build to Identify Complex Cases
+Explain to user: build needed to identify complex migration cases.
+
+Only after completing STEP 1-4, start the fast compilation check:
+```bash
+./gradlew compileDebugSources 2>&1 | tee build.log
+```
+
+Important: This is the first build run before iterative fixes.
+
+#### STEP 6: Iterative Fixes & Builder Patterns (apply_diff)
+For each compilation error:
+1. Read the error from the build log (do not restart the build)
+2. Verify that the error is related to Yandex Mobile Ads SDK classes. Do NOT attempt to fix unrelated application errors.
+3. Use `apply_diff` to fix it.
+4. Fix ALL SDK-related errors from the build log, then rebuild once to verify.
+
+Optional: If fixes are in different files and don't depend on each other, you can perform multiple `apply_diff` operations in parallel in one response.
+Important: Do not rebuild after every 5-10 fixes. Fix all SDK-related errors from the current build log, then rebuild once.
+
+Complex cases (require `apply_diff`):
+- **Listener refactoring**:
+  1. Remove `setAdLoadListener()` call (with context).
+  2. Update `loadAd()` to include listener parameter (with context).
+  3. Remove interface implementation from class declaration (if needed).
+  4. Convert listener to lambda/object (separate operation).
+- **AdRequest.Builder with adUnitId parameter**:
+  - Old: `AdRequestConfiguration.Builder().setParameters(...).build()`
+  - New: `AdRequest.Builder(adUnitId).setParameters(...).build()`
+  - Extract `adUnitId` from `setAdUnitId()` call or banner setup. Remove `setAdUnitId()` call after migration.
+- **AdTargeting extraction**:
+  - Old: `AdRequest.Builder().setAge(25).setGender(Gender.MALE)`
+  - New: `AdRequest.Builder(id).setTargeting(AdTargeting.Builder().setAge(25).setGender(Gender.MALE).build())`
+  - Move `.setAge()`, `.setGender()`, `.setLocation()` to `AdTargeting.Builder()`.
+- **Result.Success/Failure handling**.
+
+---
+
+#### STEP 7 : Verify success build and fix issues
+
+Iterate assemble application until success build, fix found issues between builds.
+
+**(Optional)** Check if the user's project uses this specific mediation adapters (`mobileads-google`, `mobileads-mytarget`, `mobileads-extras`):
+
+- **minSdk 23** — Only required if the user includes specific mediation adapters (e.g. `mobileads-google`, `mobileads-mytarget`, `mobileads-extras`). If they use these adapters and `minSdk` is lower than 23, warn them that a manifest merger failure will occur and suggest raising it to 23. Do not force this if they don't use these adapters.
+- **Kotlin 2.1.0+** — Recommended if transitive dependencies ship Kotlin 2.1 metadata (which causes errors with 1.8 compilers). If the user upgrades Kotlin to 2.0+
+- **Compose**, if Kotlin 2.1 is updated , ensure they use the `plugin.compose` compiler plugin instead of the old `composeOptions { kotlinCompilerExtensionVersion = ... }`.
+
+Do not automatically edit these Gradle settings unless the user explicitly agrees or encounters a build error related to them.
+
+---
+
+### Tool Usage Rules:
+
+| Task | Tool | Rationale |
+|------|------|-----------|
+| Import replacement | `execute_command` (sed) | Processes all files in 1 sec |
+| Simple API replacement | `execute_command` (sed) | Safe for simple patterns |
+| Complex refactoring | `apply_diff` | Requires context and precision |
+| Project build | `execute_command` (gradlew compileDebugSources) | Only after bulk replacements |
+
+---
+
+### Recommended Approach (speeds up work):
+
+1. Use `sed` for bulk replacements (imports, simple APIs), but apply them ONE BY ONE (one pattern per command).
+2. Group changes: first process imports (one by one), then simple APIs (one by one).
+3. Start the compilation check only after bulk replacements
+4. Use `apply_diff` only for complex cases
+5. Read the build log once, fix several errors, then re-run compilation check
+
+---
+
+## Migrate to Yandex Ads SDK 8
+
+* When I ask to migrate to **Yandex Mobile Ads SDK 8**, start modifying files immediately in the same response without asking for confirmation.
+* Assume **Yandex artifact versions** in `build.gradle.kts` are already set by the user. Do not change **Yandex / mediation dependency coordinates** unless the user asks.
+* **Exception:** always run **STEP 0** first to check for optional build toolchain updates. Do not force changes unless the user encounters errors.
+* Follow the Fast Migration Strategy above to avoid slow iterative approach.
+
+---
+
+
+### 1. Package Import Changes (Most Important)
+
+Some SDK classes were moved to different packages. Ensure all imports match the **SDK 8** package layout.
+
+Action:
+1. Replace old class imports with their new package locations throughout the codebase
+2. After replacing imports, remove all unused/old imports to prevent compilation errors
+3. Exception: Only user's application package imports remain unchanged (e.g., `com.yourcompany.yourapp.*` - this is application code, not SDK)
+
+### 2. Special Integration Cases
+
+media3.YandexAdsLoader:
+- See **Complete Package Structure** → row *Instream Media3 (ExoPlayer)* and **Class Mapping** → *Instream ExoPlayer/Media3 ads insertion* and *Instream Ad Request* (constructor argument type for the loader).
+
+Custom Player Implementations:
+- If implementing `InstreamAdPlayer`, add new required methods:
+  * `supportedMimeTypes: List<String>`
+  * `bindPlayerView(container: FrameLayout)`
+
+---
+
+## Complete Package Structure (SDK 8)
+
+All SDK imports must use `com.yandex.mobile.ads.*` prefix:
+
+| Feature Area | Package | Key Classes |
+|--------------|---------|-------------|
+| Core/Common | `com.yandex.mobile.ads.common.*` | `YandexAds`, `AdRequest`, `AdRequestError`, `AdError`, `ImpressionData`, `AdBindingResult`, `Result`, `Result.Success`, `Result.Failure` |
+| Banner | `com.yandex.mobile.ads.banner.*` | `BannerAdView`, `BannerAdSize`, `BannerAdEventListener` |
+| Interstitial | `com.yandex.mobile.ads.interstitial.*` | `InterstitialAd`, `InterstitialAdLoader`, `InterstitialAdLoadListener`, `InterstitialAdEventListener` |
+| Rewarded | `com.yandex.mobile.ads.rewarded.*` | `RewardedAd`, `RewardedAdLoader`, `RewardedAdLoadListener`, `RewardedAdEventListener`, `Reward` |
+| App Open | `com.yandex.mobile.ads.appopenad.*` | `AppOpenAd`, `AppOpenAdLoader`, `AppOpenAdLoadListener`, `AppOpenAdEventListener` |
+| Native Ads | `com.yandex.mobile.ads.nativeads.*` | `NativeAd`, `NativeAdLoader`, `NativeAdLoadListener`, `NativeAdEventListener`, `NativeAdViewBinder`, `NativeAdAssets`, `NativeAdWarning`, `NativeAdOptions`, `SliderAd`, `SliderAdLoader`, `SliderAdLoadListener`, `FeedAd`, `FeedAdAdapter`, `FeedAdAppearance`, `FeedAdLoadListener`, `FeedAdEventListener` |
+| Instream | `com.yandex.mobile.ads.instream.*` | `InstreamAd`, `InstreamAdLoader`, `InstreamAdLoadListener`, `InstreamAdListener`, `InstreamAdRequest`, `InstreamAdRequestError`, `YandexInstreamAds`, `InstreamAdBreakType`, `InstreamAdBreakEventListener` |
+| Instream Binder | `com.yandex.mobile.ads.instream.binder.*` | `InstreamAdBinder` |
+| Instream Ad Break | `com.yandex.mobile.ads.instream.adbreak.*` | `InstreamAdBreak`, `AdBreakData` |
+| Instream Player | `com.yandex.mobile.ads.instream.player.*` | `InstreamAdPlayer`, `InstreamAdPlayerListener` |
+| Instream Player Content | `com.yandex.mobile.ads.instream.player.content.*` | `VideoPlayer`, `VideoPlayerListener` |
+| Instream Player Ad | `com.yandex.mobile.ads.instream.player.ad.*` | `InstreamAdPlayer`, `InstreamAdPlayerListener`, `InstreamAdMimeTypes` |
+| Instream Media3 (ExoPlayer) | `com.yandex.mobile.ads.instream.media3.*` | `YandexAdsLoader` — local ad insertion with Media3; import was `instream.exoplayer.YandexAdsLoader` on older 7.x |
+
+---
+
+## Class Mapping
+
+| Feature | Old SDK 7.x | New SDK 8 | Full Package Path |
+|---------|-------------|-------------|-------------------|
+| Instream SDK Class | `MobileInstream` | `YandexInstreamAds` | `com.yandex.mobile.ads.instream.YandexInstreamAds` |
+| Main SDK Class | `MobileAds` | `YandexAds` | `com.yandex.mobile.ads.common.YandexAds` |
+| Ad Request | `AdRequestConfiguration` | `AdRequest` | `com.yandex.mobile.ads.common.AdRequest` |
+| Ad Request Builder | `AdRequestConfiguration.Builder` | `AdRequest.Builder` | `com.yandex.mobile.ads.common.AdRequest.Builder` |
+| Native Ad Request | `NativeAdRequestConfiguration` | `AdRequest` | `com.yandex.mobile.ads.common.AdRequest` |
+| Instream Ad Request | `InstreamAdRequestConfiguration` | `InstreamAdRequest` | `com.yandex.mobile.ads.instream.InstreamAdRequest` |
+| Instream ExoPlayer/Media3 ads insertion | `YandexAdsLoader` | `YandexAdsLoader` (same class name) | Import/package change: `com.yandex.mobile.ads.instream.exoplayer.YandexAdsLoader` → `com.yandex.mobile.ads.instream.media3.YandexAdsLoader` (use with AndroidX Media3 / `DefaultMediaSourceFactory` local ad insertion; not a replacement for `InstreamAdLoader`) |
+| Ad Targeting | N/A (was in AdRequest.Builder) | `AdTargeting` | `com.yandex.mobile.ads.common.AdTargeting` |
+| Ad Targeting Builder | N/A | `AdTargeting.Builder` | `com.yandex.mobile.ads.common.AdTargeting.Builder` |
+| Native Template View | `NativeBannerView` | `NativeAdView` | `com.yandex.mobile.ads.nativeads.NativeAdView` |
+| Native Template Appearance | `NativeTemplateAppearance` | (removed - use custom layouts) | N/A |
+| Size Constraint | `SizeConstraint` | (removed) | N/A |
+| Banner Event Listener | `ClosableBannerAdEventListener` | `BannerAdEventListener` | `com.yandex.mobile.ads.banner.BannerAdEventListener` |
+
+---
+
+## Method Mapping
+
+| Feature | Old SDK 7.x | New SDK 8 |
+|---------|-------------|-------------|
+| Initialization | `MobileAds.initialize(...)` | `YandexAds.initialize(...)` |
+| Instream Initialization | `MobileInstream.setAdGroupPreloading(...)` | `YandexInstreamAds.setAdGroupPreloading(...)` |
+| Banner Setup | `banner.setAdUnitId(id)`<br>`banner.setAdSize(size)`<br>`banner.setBannerAdEventListener(listener)`<br>`banner.loadAd(AdRequest.Builder().build())` | `banner.setAdSize(size)`<br>`banner.setBannerAdEventListener(listener)`<br>`banner.loadAd(AdRequest.Builder(id).build())` |
+| Interstitial Load | `loader.setAdLoadListener(listener)`<br>`loader.loadAd(config)` | `loader.loadAd(request, listener)` |
+| Native Load | `loader.setNativeAdLoadListener(listener)`<br>`loader.loadAd(config)` | `loader.loadAd(request, listener)` |
+| Rewarded Load | `loader.setAdLoadListener(listener)`<br>`loader.loadAd(config)` | `loader.loadAd(request, listener)` |
+| App Open Load | `loader.setAdLoadListener(listener)`<br>`loader.loadAd(config)` | `loader.loadAd(request, listener)` |
+| Instream Load | `loader.setInstreamAdLoadListener(listener)`<br>`loader.loadInstreamAd(request)` | `loader.loadInstreamAd(request, listener)` |
+| Slider Load | `loader.setSliderAdLoadListener(listener)`<br>`loader.loadSlider(config)` | `loader.loadAd(request, listener)` or<br>`loader.loadAd(request, options, listener)` |
+| Bulk Native Load | `loader.setNativeBulkAdLoadListener(listener)`<br>`loader.loadAds(config, count)` | `loader.loadAds(request, count, listener)` |
+| Banner Size (Sticky) | `BannerAdSize.stickySize(context, width)` | `BannerAdSize.sticky(context, width)` |
+| Banner Size (Inline) | `BannerAdSize.inlineSize(context, width, maxHeight)` | `BannerAdSize.inline(context, width, maxHeight)` |
+| Ad Show (Interstitial/Rewarded/AppOpen) | `ad.setAdEventListener(listener)`<br>`ad.show(activity)` | `ad.setAdEventListener(listener)`<br>`ad.show(activity)` |
+| Native Binding | `try { ad.bindNativeAd(binder) } catch (e: NativeAdException)` | `when (ad.bindNativeAd(binder)) { is AdBindingResult.Failure -> ..., is AdBindingResult.Success -> ... }` |
+
+---
+
+## Property & Type Changes
+
+| Feature | Old SDK 7.x | New SDK 8 | Full Type Path |
+|---------|-------------|-------------|----------------|
+| Native Warning | `ad.adAssets.warning: String?` | `ad.adAssets.warning: NativeAdWarning?`<br>Use `.value` for text, `.minimumRequiredArea` for size | `com.yandex.mobile.ads.nativeads.NativeAdWarning` |
+| AdInfo Data | `ad.info`<br>`ad.adInfo.data` | `ad.adInfo.extraData` | N/A |
+| Creative ID | `nativeAd.creativeId` | `ad.adInfo.creatives.first().creativeId` | N/A |
+| Campaign ID | `nativeAd.campaignId` | `ad.adInfo.creatives.first().campaignId` | N/A |
+| Banner Ad Size | `ad.adInfo.adSize` | `banner.adSize` (only for banner, removed for others) | N/A |
+
+---
+
+## Privacy & Consent Methods
+
+| Feature | Old SDK 7.x | New SDK 8 |
+|---------|-------------|-------------|
+| Age Restriction | `MobileAds.setAgeRestrictedUser(value)` | `YandexAds.setAgeRestricted(value)` (renamed) |
+| Location Consent | `MobileAds.setLocationConsent(value)` | `YandexAds.setLocationTracking(value)` |
+| User Consent | `MobileAds.setUserConsent(value)` | `YandexAds.setUserConsent(value)` (unchanged) |
+
+---
+
+## Removed APIs & Alternatives
+
+| Removed API | Alternative | Migration Action |
+|-------------|-------------|------------------|
+| `NativeBannerView` | `NativeAdBannerView` (from public sample) | Copy `NativeAdBannerView.kt` + `native_banner_ad_view.xml` from the Yandex Mobile Ads public sample. Replace XML tag and update call sites: `setAd()` → `bindNativeAd()`, add `release()`. |
+| `NativeTemplateAppearance` | Custom XML layout attributes | Delete all appearance builder code. Visual customization is now done directly via XML attributes on the child views inside `NativeAdView`. |
+| `ButtonAppearance` | `Button` XML attributes | Delete builder. Use `android:textColor`, `android:background`, `android:textSize` on your CTA `Button`. |
+| `ImageAppearance` | `ImageView` XML attributes | Delete builder. Use `android:scaleType`, `android:layout_width`, `android:layout_height` on your `ImageView`. |
+| `LabelAppearance` / `TextAppearance` | `TextView` XML attributes | Delete builder. Use `android:textColor`, `android:textSize`, `android:fontFamily` on your `TextView`. |
+| `RatingAppearance` | Custom rating view attributes | Delete builder. Configure your custom rating view directly in XML. |
+| `SizeConstraint` | Standard Android layout constraints | Delete builder. Use `android:layout_width`, `android:layout_height`, or `ConstraintLayout` constraints. |
+| `ClosableBannerAdEventListener.onAdClosed()` | No direct replacement | Extract business logic to a separate method (e.g., `fun onAdClosed()`). Find where `onAdClosed()` was previously called in the app code and insert the new method call there. Add `// FIXME_SDK8: verify invocation point` comment. |
+| `onLeftApplication()` / `onReturnedToApplication()` | Removed from listeners - extract business logic and remove `@Override` / `override` | Delete method overrides completely |
+| `AdRequest.Builder().setAge/Gender/Location()` | Move to `AdTargeting.Builder()`, pass via `AdRequest.Builder().setTargeting()` | Extract targeting calls, wrap in `AdTargeting.Builder()`, pass to `setTargeting()` |
+| `AdRequest.Builder().setShouldLoadImagesAutomatically()` | Move to `NativeAdOptions` for native ads | Remove from `AdRequest.Builder`, pass to `NativeAdLoader.loadAd(request, options, listener)` where `options = NativeAdOptions.Builder().setShouldLoadImagesAutomatically(value).build()` |
+| `BannerAdView.setAdUnitId()` | Pass `adUnitId` to `AdRequest.Builder()` constructor | Remove `setAdUnitId()` call, extract value, pass to `AdRequest.Builder(adUnitId)` |
+| `InrollQueueProvider` | Use `instreamAd.instreamAdBreaks.filter { it.adBreakData.type == InstreamAdBreakType.INROLL }` | Remove provider instantiation, replace queue access with filter expression |
+| `PauserollQueueProvider` | Use `instreamAd.instreamAdBreaks.filter { it.adBreakData.type == InstreamAdBreakType.PAUSEROLL }` | Remove provider instantiation, replace queue access with filter expression |
+| `InstreamAdBreak.invalidate()` | Removed - just remove from memory | Delete method calls completely |
+
+---
+
+## Listener Refactoring Patterns
+
+### Pattern 1: Interstitial/Rewarded/AppOpen Load Listener
+
+Migration Steps:
+1. Remove `setAdLoadListener(this)` or `setAdLoadListener(listener)` call
+2. Remove interface implementation from class declaration (if class implements listener)
+3. Pass listener as second parameter to `loadAd(request, listener)`
+4. Convert listener to object expression or lambda if needed
+
+### Pattern 2: Native Ad Load Listener
+
+Migration Steps:
+1. Remove `setNativeAdLoadListener(listener)` call
+2. Update `loadAd()` to accept two parameters: `loadAd(request, listener)`
+
+### Pattern 3: Instream Ad Load Listener
+
+Migration Steps:
+1. Remove `setInstreamAdLoadListener(listener)` call
+2. Pass listener directly to `loadInstreamAd(request, listener)`
+3. Update error parameter type from `String` to `InstreamAdRequestError`
+4. Use `error.description` to get error message
+
+### Pattern 4: Banner Event Listener
+
+Migration Steps:
+1. Change listener type from `ClosableBannerAdEventListener` to `BannerAdEventListener`
+2. Remove `onAdClosed()` method override completely
+3. Extract business logic from `override fun onAdClosed()` to a separate method (e.g., `fun onAdClosed()`)
+4. Find the exact place in the application code where `onAdClosed()` was previously being called and insert the call to your new method there.
+5. Add a `// FIXME_SDK8: onAdClosed logic migrated from SDK 7.x - verify invocation point` comment at the new call site.
+
+---
+
+# Instream SDK Migration to SDK 8
+
+## Instream Package Changes
+
+| Old SDK 7.x | New SDK 8 | Full Package Path |
+|-------------|-------------|-------------------|
+| `com.yandex.mobile.ads.instream.InstreamAdBinder` | `com.yandex.mobile.ads.instream.binder.InstreamAdBinder` | `com.yandex.mobile.ads.instream.binder.InstreamAdBinder` |
+| `InstreamAdRequestConfiguration` | `InstreamAdRequest` | `com.yandex.mobile.ads.instream.InstreamAdRequest` |
+| `InstreamAdBreak` | `adbreak.InstreamAdBreak` | `com.yandex.mobile.ads.instream.adbreak.InstreamAdBreak` |
+| `inroll.Inroll` | `adbreak.InstreamAdBreak` | `com.yandex.mobile.ads.instream.adbreak.InstreamAdBreak` |
+| `pauseroll.Pauseroll` | `adbreak.InstreamAdBreak` | `com.yandex.mobile.ads.instream.adbreak.InstreamAdBreak` |
+| `InrollQueueProvider` | (removed - use `instreamAd.instreamAdBreaks.filter`) | N/A |
+| `PauserollQueueProvider` | (removed - use `instreamAd.instreamAdBreaks.filter`) | N/A |
+
+## Instream Method Changes
+
+| Feature | Old SDK 7.x | New SDK 8 |
+|---------|-------------|-------------|
+| Instream Load | `loader.setInstreamAdLoadListener(listener)`<br>`loader.loadInstreamAd(request)` | `loader.loadInstreamAd(request, listener)` |
+| Error Callback | `onInstreamAdFailedToLoad(reason: String)` | `onInstreamAdFailedToLoad(error: InstreamAdRequestError)` - use `error.description` |
+| Binder Player | `InstreamAdBinder(context, ad, player, videoPlayer)` | Player is now optional: `InstreamAdBinder(context, ad, null, videoPlayer)` |
+| Ad Break Prepare | `adBreak.prepare(player)` | Player is optional: `adBreak.prepare()` or `adBreak.prepare(player)` |
+| Queue Access | `InrollQueueProvider(context, ad).queue.poll()` | `instreamAd.instreamAdBreaks.filter { it.adBreakData.type == InstreamAdBreakType.INROLL }.getOrNull(index)` |
+
+## Instream Player Interface Updates
+
+`InstreamAdPlayer` interface has new required methods:
+
+- `override val supportedMimeTypes: List<String>` - return list of supported MIME types
+  * Use constants from `InstreamAdMimeTypes`: `MP4`, `WEBM`, `DASH`, `HLS`, etc.
+  * If constant not available, fallback to string literal
+- `override fun bindPlayerView(container: FrameLayout)` - add your player view to the provided container with MATCH_PARENT layout params
+
+---
+
+## Interface Signature Changes
+
+### Banner Event Listener
+- Removed: `onAdClosed()` method
+
+### Interstitial/Rewarded/AppOpen Load Listener
+- Changed: Pass listener directly to `loadAd()` instead of `setAdLoadListener()`
+
+### Native Ad Load Listener
+- Changed: Pass listener directly to `loadAd()` instead of `setNativeAdLoadListener()`
+
+### Instream Ad Load Listener
+- Changed: `onInstreamAdFailedToLoad(reason: String)` → `onInstreamAdFailedToLoad(error: InstreamAdRequestError)`
+
+### Instream Ad Break Event Listener
+- Renamed: `InrollEventListener` → `InstreamAdBreakEventListener`
+- Renamed methods: `onInrollPrepared()` → `onInstreamAdBreakPrepared()`, etc.
+- Changed: `onInrollError(reason: String)` → `onInstreamAdBreakError(reason: String)`
+
+---
+
+## AI Migration Principles
+
+1. Preserve Logic: Make changes only related to Yandex Mobile Ads SDK upgrade to **SDK 8**. Do not change business logic.
+2. Preserve Names: Keep variable names, method names (except SDK API)
+3. Preserve Order: Keep code order unless API requires change
+4. Extract Values: When transforming, extract actual values (like `adUnitId`) and reuse them
+5. Combine Calls: When setter + method pattern found, combine into single method call
+6. Update Types: When type changes (String → NativeAdWarning), update variable type and access
+7. Handle Java: Use `new ClassName() { ... }` for anonymous classes in `.java` files, not Kotlin's `object :`
+8. Simplify Queues: Replace Instream queue providers with direct list filtering
+9. Optional Players: Consider using `null` for Instream player parameters when SDK default is acceptable
+10. Import Cleanup: After migration, remove ALL old imports and add correct `com.yandex.mobile.ads.*` imports
+
+---
+
+
+## Version Info
+
+- Source: SDK 7.x
+- Target: SDK 8
+- Updated: March 2026
+- Package Structure Change: Added March 2026
+- Complete Interface Documentation: Added March 2026

--- a/changelogs/adapter/admob/CHANGELOG.md
+++ b/changelogs/adapter/admob/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Yandex Adapter for AdMob Mediation will be documented in this file.
 
+## Version 8.0.0.0-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+
 ## Version 7.18.4.0
 
 #### Updated

--- a/changelogs/adapter/admob/CHANGELOG.md
+++ b/changelogs/adapter/admob/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 All notable changes to Yandex Adapter for AdMob Mediation will be documented in this file.
 
-## Version 8.0.0.0-beta.1
+## Version 8.0.0.0
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 
 ## Version 7.18.4.0
 

--- a/changelogs/mediation/applovin/CHANGELOG.md
+++ b/changelogs/mediation/applovin/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to AppLovin Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 13.5.1.0-beta.1
+## Version 13.5.1.0
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 * Applovin SDK version 13.5.1
 
 ## Version 13.1.0.12

--- a/changelogs/mediation/applovin/CHANGELOG.md
+++ b/changelogs/mediation/applovin/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to AppLovin Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 13.5.1.0-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Applovin SDK version 13.5.1
+
 ## Version 13.1.0.12
 
 #### Updated

--- a/changelogs/mediation/appnext/CHANGELOG.md
+++ b/changelogs/mediation/appnext/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to AppNext Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 2.7.6.473.20-beta.1
+## Version 2.7.6.473.20
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 
 ## Version 2.7.6.473.19
 

--- a/changelogs/mediation/appnext/CHANGELOG.md
+++ b/changelogs/mediation/appnext/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to AppNext Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 2.7.6.473.20-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+
 ## Version 2.7.6.473.19
 
 #### Updated

--- a/changelogs/mediation/bigoads/CHANGELOG.md
+++ b/changelogs/mediation/bigoads/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Change Log
 All notable changes to Bigo Ads Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 5.7.0.0
+
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 * Bigoads SDK version 5.7.0
 
 ## Version 5.5.1.2

--- a/changelogs/mediation/bigoads/CHANGELOG.md
+++ b/changelogs/mediation/bigoads/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to Bigo Ads Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Bigoads SDK version 5.7.0
+
 ## Version 5.5.1.2
 
 #### Updated

--- a/changelogs/mediation/chartboost/CHANGELOG.md
+++ b/changelogs/mediation/chartboost/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to ChartBoost Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 9.3.1.28-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+
 ## Version 9.3.1.27
 
 #### Updated

--- a/changelogs/mediation/chartboost/CHANGELOG.md
+++ b/changelogs/mediation/chartboost/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to ChartBoost Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 9.3.1.28-beta.1
+## Version 9.3.1.28
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 
 ## Version 9.3.1.27
 

--- a/changelogs/mediation/digitalturbine/CHANGELOG.md
+++ b/changelogs/mediation/digitalturbine/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to Digital Turbine Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 8.4.3.0-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Digitalturbine SDK version 8.4.3
+
 ## Version 8.4.1.1
 
 #### Updated

--- a/changelogs/mediation/digitalturbine/CHANGELOG.md
+++ b/changelogs/mediation/digitalturbine/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to Digital Turbine Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 8.4.3.0-beta.1
+## Version 8.4.3.0
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 * Digitalturbine SDK version 8.4.3
 
 ## Version 8.4.1.1

--- a/changelogs/mediation/google/CHANGELOG.md
+++ b/changelogs/mediation/google/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to AdMob Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 24.9.0.0-beta.1
+## Version 24.9.0.0
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 * Google SDK version 24.9.0
 
 ## Version 23.6.0.10

--- a/changelogs/mediation/google/CHANGELOG.md
+++ b/changelogs/mediation/google/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to AdMob Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 24.9.0.0-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Google SDK version 24.9.0
+
 ## Version 23.6.0.10
 
 #### Updated

--- a/changelogs/mediation/inmobi/CHANGELOG.md
+++ b/changelogs/mediation/inmobi/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to InMobi Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 11.0.0.0-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Inmobi SDK version 11.0.0
+
 ## Version 10.8.7.2
 
 #### Updated

--- a/changelogs/mediation/inmobi/CHANGELOG.md
+++ b/changelogs/mediation/inmobi/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to InMobi Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 11.0.0.0-beta.1
+## Version 11.0.0.0
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 * Inmobi SDK version 11.0.0
 
 ## Version 10.8.7.2

--- a/changelogs/mediation/ironsource/CHANGELOG.md
+++ b/changelogs/mediation/ironsource/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to IronSource Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 9.2.0.0-beta.1
+## Version 9.2.0.0
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 * Ironsource SDK version 9.2.0
 
 ## Version 9.0.0.0

--- a/changelogs/mediation/ironsource/CHANGELOG.md
+++ b/changelogs/mediation/ironsource/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to IronSource Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 9.2.0.0-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Ironsource SDK version 9.2.0
+
 ## Version 9.0.0.0
 
 #### Updated

--- a/changelogs/mediation/mintegral/CHANGELOG.md
+++ b/changelogs/mediation/mintegral/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to Yandex Adapter for Mintegral Mediation will be documented in this file.
 
+## Version 17.0.41.0-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Mintegral SDK version 17.0.41
+
 ## Version 17.0.31.0
 
 #### Updated

--- a/changelogs/mediation/mintegral/CHANGELOG.md
+++ b/changelogs/mediation/mintegral/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to Yandex Adapter for Mintegral Mediation will be documented in this file.
 
-## Version 17.0.41.0-beta.1
+## Version 17.0.41.0
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 * Mintegral SDK version 17.0.41
 
 ## Version 17.0.31.0

--- a/changelogs/mediation/mytarget/CHANGELOG.md
+++ b/changelogs/mediation/mytarget/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Change Log
 All notable changes to MyTarget Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 	5.45.3.1-beta.1
+
+#### Breaking Changes
+* Raised the Android minSdk version to 23
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Mytarget SDK version 5.45.3
+
 ## Version 5.27.4.1
 
 #### Updated

--- a/changelogs/mediation/mytarget/CHANGELOG.md
+++ b/changelogs/mediation/mytarget/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Change Log
 All notable changes to MyTarget Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 	5.45.3.1-beta.1
+## Version 5.45.3.1
 
-#### Breaking Changes
-* Raised the Android minSdk version to 23
+#### Breaking changes
+* Raise the Android minSdk version to 23
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 * Mytarget SDK version 5.45.3
 
 ## Version 5.27.4.1

--- a/changelogs/mediation/pangle/CHANGELOG.md
+++ b/changelogs/mediation/pangle/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to Pangle Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 7.8.0.7.0-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Pangle SDK version 7.8.0.7
+
 ## Version 6.5.1.2.2
 
 #### Updated

--- a/changelogs/mediation/pangle/CHANGELOG.md
+++ b/changelogs/mediation/pangle/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to Pangle Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 7.8.0.7.0-beta.1
+## Version 7.8.0.7.0
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 * Pangle SDK version 7.8.0.7
 
 ## Version 6.5.1.2.2
@@ -176,7 +176,6 @@ All notable changes to Pangle Adapter for Yandex Mobile Ads Mediation will be do
 ## Version 5.2.0.7.0
 * Added support for Pangle sdk version 5.2.0.7
 * Updated minimum supported Pangle sdk version to 5.2.0.7
-
 
 ## Version 4.9.1.5.0
 

--- a/changelogs/mediation/petalads/CHANGELOG.md
+++ b/changelogs/mediation/petalads/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to PetalAds Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 3.4.79.301.7-beta.1
+## Version 3.4.79.301.7
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 
 ## Version 3.4.79.301.6
 

--- a/changelogs/mediation/petalads/CHANGELOG.md
+++ b/changelogs/mediation/petalads/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Change Log
+All notable changes to PetalAds Adapter for Yandex Mobile Ads Mediation will be documented in this file.
+
+## Version 3.4.79.301.7-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+
 ## Version 3.4.79.301.6
 
 #### Updated

--- a/changelogs/mediation/startapp/CHANGELOG.md
+++ b/changelogs/mediation/startapp/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to StartApp Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 5.0.2.20-beta.1
+## Version 5.0.2.20
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 
 ## Version 5.0.2.19
 

--- a/changelogs/mediation/startapp/CHANGELOG.md
+++ b/changelogs/mediation/startapp/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to StartApp Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 5.0.2.20-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+
 ## Version 5.0.2.19
 
 #### Updated

--- a/changelogs/mediation/tapjoy/CHANGELOG.md
+++ b/changelogs/mediation/tapjoy/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to TapJoy Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 14.3.1.9-beta.1
+## Version 14.3.1.9
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 
 ## Version 14.3.1.8
 

--- a/changelogs/mediation/tapjoy/CHANGELOG.md
+++ b/changelogs/mediation/tapjoy/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to TapJoy Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 14.3.1.9-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+
 ## Version 14.3.1.8
 
 #### Updated

--- a/changelogs/mediation/unityads/CHANGELOG.md
+++ b/changelogs/mediation/unityads/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to UnityAds Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 4.16.5.0-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Unityads SDK version 4.16.5
+
 ## Version 4.16.4.0
 
 #### Updated

--- a/changelogs/mediation/unityads/CHANGELOG.md
+++ b/changelogs/mediation/unityads/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to UnityAds Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 4.16.5.0-beta.1
+## Version 4.16.5.0
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 * Unityads SDK version 4.16.5
 
 ## Version 4.16.4.0

--- a/changelogs/mediation/vungle/CHANGELOG.md
+++ b/changelogs/mediation/vungle/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to Vungle Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
+## Version 7.7.0.0-beta.1
+
+#### Updated
+* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Vungle SDK version 7.7.0
+
 ## Version 7.6.1.0
 
 #### Updated

--- a/changelogs/mediation/vungle/CHANGELOG.md
+++ b/changelogs/mediation/vungle/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to Vungle Adapter for Yandex Mobile Ads Mediation will be documented in this file.
 
-## Version 7.7.0.0-beta.1
+## Version 7.7.0.0
 
 #### Updated
-* Yandex Mobile Ads SDK version 8.0.0-beta.1
+* Yandex Mobile Ads SDK version 8.0.0
 * Vungle SDK version 7.7.0
 
 ## Version 7.6.1.0

--- a/changelogs/mobileads-mediation/CHANGELOG.md
+++ b/changelogs/mobileads-mediation/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Yandex Full Mediation will be documented in this file.
 
+## Version 8.0.0.0-beta.1
+
+#### Breaking changes
+
+* Raised the Android minSdk version to 23
+
+#### Updated
+
+* Yandex Mobile Ads SDK 8.0.0-beta.1
+
 ## Version 7.18.2.0
 
 #### Updated

--- a/changelogs/mobileads-mediation/CHANGELOG.md
+++ b/changelogs/mobileads-mediation/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Yandex Full Mediation will be documented in this file.
 
-## Version 8.0.0.0-beta.1
+## Version 8.0.0.0
 
 #### Breaking changes
 
@@ -10,7 +10,7 @@ All notable changes to Yandex Full Mediation will be documented in this file.
 
 #### Updated
 
-* Yandex Mobile Ads SDK 8.0.0-beta.1
+* Yandex Mobile Ads SDK 8.0.0
 
 ## Version 7.18.2.0
 

--- a/changelogs/mobileads/CHANGELOG.md
+++ b/changelogs/mobileads/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to Yandex Mobile Ads SDK will be documented in this file.
 
+## Version 8.0.0-beta.1
+
+### Breaking Changes
+
+* Removed `AdRequestConfiguration` and `NativeAdRequestConfiguration` → use `AdRequest`
+* Removed `BannerAdView.setAdUnitId()` → pass `adUnitId` to `AdRequest.Builder("id")`
+* Removed `setAge`, `setGender`, `setLocation`, `setContextQuery`, `setContextTags` from `AdRequest.Builder` → use `AdTargeting`
+* Removed `setAdLoadListener` and similar setters → pass listener directly to `loadAd()`
+* Removed `BannerAdSize.stickySize` and `BannerAdSize.inlineSize` → use `sticky` and `inline`
+* Removed `info` and `adAttributes` → use `adInfo`; removed `AdInfo.data` and `AdInfo.adSize`
+* Removed `NativeAd.creativeId` and `NativeAd.campaignId` → use `adInfo.creatives`
+* Changed `warning` type in `NativeAdAssets`: `String?` → `NativeAdWarning?`
+* `bindNativeAd` and `bindSliderAd` no longer throw exceptions → return `AdBindingResult`
+* Removed native ad templates: `NativeBannerView`, `NativeTemplateAppearance`, `SizeConstraint`, and related classes
+* Removed `ClosableBannerAdEventListener` and `ClosableNativeAdEventListener`
+* Removed `onLeftApplication` and `onReturnToApplication` callbacks
+* Removed `MobileAds` → use `YandexAds`; `setAgeRestrictedUser` → `setAgeRestricted`; `setLocationConsent` → `setLocationTracking`
+* Removed `InstreamAdRequestConfiguration` → use `InstreamAdRequest`
+* Moved `InstreamAdBinder` to `com.yandex.mobile.ads.instream.binder` package
+* Renamed `InstreamAdBreak` → `AdBreakData`; replaced `Inroll` and `Pauseroll` → `InstreamAdBreak`
+* Removed `InrollQueueProvider` and `PauserollQueueProvider` → use `instreamAd.instreamAdBreaks` with type filter
+* Changed `onInstreamAdFailedToLoad(String)` → `onInstreamAdFailedToLoad(InstreamAdRequestError)`
+* Removed `setInstreamAdLoadListener` → pass listener directly to `loadAd()`
+
+### Added
+
+* `AdTargeting` and `AdTargeting.Builder` for targeting parameters
+* `suspend` overloads for all ad loaders (Kotlin Coroutines) with sealed `Success`/`Failure` results
+* `AdInfo.creatives`, `AdInfo.extraData`, `AdInfo.partnerText`
+* `Creative.placeId`, `Creative.offerId`
+* `NativeAdWarning` with `value` and `minimumRequiredArea`
+* `NativeAdMedia.hasVideo`
+* `AdBindingResult`
+* `InstreamAdBreakLoader` and `InstreamAdBreakLoadListener`
+* `InstreamAdBreakRequest`
+* `suspend` overloads for `InstreamAdLoader` and `InstreamAdBreakLoader`
+
+### Updated
+
+* `AdRequest.Builder` now accepts `adUnitId` as a constructor parameter
+* `loadAd()` on all loaders now accepts listener as a parameter
+* `NativeAdLoader.loadAd`, `SliderAdLoader.loadSlider`, `NativeBulkAdLoader.loadAds` — `NativeAdOptions` is now an optional parameter
+
 ## Version 7.18.4
 
 #### Fixed

--- a/changelogs/mobileads/CHANGELOG.md
+++ b/changelogs/mobileads/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Yandex Mobile Ads SDK will be documented in this file.
 
-## Version 8.0.0-beta.1
+## Version 8.0.0
 
 ### Breaking Changes
 
@@ -38,6 +38,7 @@ All notable changes to Yandex Mobile Ads SDK will be documented in this file.
 * `InstreamAdBreakLoader` and `InstreamAdBreakLoadListener`
 * `InstreamAdBreakRequest`
 * `suspend` overloads for `InstreamAdLoader` and `InstreamAdBreakLoader`
+* Added 8.x AI-assisted migration tool. See [migration guide](../../YandexMobileAdsExample/skills/migrate-yandex-ads-sdk-from-7-to-8/README.md).
 
 ### Updated
 


### PR DESCRIPTION
## Version 8.0.0
* [Full migration guideline](https://ads.yandex.com/helpcenter/ru/dev/android/release/8-0-0-migration)
* [AI migration guideline](https://ads.yandex.com/helpcenter/ru/dev/android/release/8-0-0-migration#ai)

### Breaking Changes

* Removed `AdRequestConfiguration` and `NativeAdRequestConfiguration` → use `AdRequest`
* Removed `BannerAdView.setAdUnitId()` → pass `adUnitId` to `AdRequest.Builder("id")`
* Removed `setAge`, `setGender`, `setLocation`, `setContextQuery`, `setContextTags` from `AdRequest.Builder` → use `AdTargeting`
* Removed `setAdLoadListener` and similar setters → pass listener directly to `loadAd()`
* Removed `BannerAdSize.stickySize` and `BannerAdSize.inlineSize` → use `sticky` and `inline`
* Removed `info` and `adAttributes` → use `adInfo`; removed `AdInfo.data` and `AdInfo.adSize`
* Removed `NativeAd.creativeId` and `NativeAd.campaignId` → use `adInfo.creatives`
* Changed `warning` type in `NativeAdAssets`: `String?` → `NativeAdWarning?`
* `bindNativeAd` and `bindSliderAd` no longer throw exceptions → return `AdBindingResult`
* Removed native ad templates: `NativeBannerView`, `NativeTemplateAppearance`, `SizeConstraint`, and related classes
* Removed `ClosableBannerAdEventListener` and `ClosableNativeAdEventListener`
* Removed `onLeftApplication` and `onReturnToApplication` callbacks
* Removed `MobileAds` → use `YandexAds`; `setAgeRestrictedUser` → `setAgeRestricted`; `setLocationConsent` → `setLocationTracking`
* Removed `InstreamAdRequestConfiguration` → use `InstreamAdRequest`
* Moved `InstreamAdBinder` to `com.yandex.mobile.ads.instream.binder` package
* Renamed `InstreamAdBreak` → `AdBreakData`; replaced `Inroll` and `Pauseroll` → `InstreamAdBreak`
* Removed `InrollQueueProvider` and `PauserollQueueProvider` → use `instreamAd.instreamAdBreaks` with type filter
* Changed `onInstreamAdFailedToLoad(String)` → `onInstreamAdFailedToLoad(InstreamAdRequestError)`
* Removed `setInstreamAdLoadListener` → pass listener directly to `loadAd()`

### Added

* `AdTargeting` and `AdTargeting.Builder` for targeting parameters
* `suspend` overloads for all ad loaders (Kotlin Coroutines) with sealed `Success`/`Failure` results
* `AdInfo.creatives`, `AdInfo.extraData`, `AdInfo.partnerText`
* `Creative.placeId`, `Creative.offerId`
* `NativeAdWarning` with `value` and `minimumRequiredArea`
* `NativeAdMedia.hasVideo`
* `AdBindingResult`
* `InstreamAdBreakLoader` and `InstreamAdBreakLoadListener`
* `InstreamAdBreakRequest`
* `suspend` overloads for `InstreamAdLoader` and `InstreamAdBreakLoader`
* Added 8.x AI-assisted migration tool

### Updated

* `AdRequest.Builder` now accepts `adUnitId` as a constructor parameter
* `loadAd()` on all loaders now accepts listener as a parameter
* `NativeAdLoader.loadAd`, `SliderAdLoader.loadSlider`, `NativeBulkAdLoader.loadAds` — `NativeAdOptions` is now an optional parameter
